### PR TITLE
Update RPM to depend on (jre), not (java).

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -152,7 +152,7 @@ def doRPM(Rule rule)
 			}
 
 	if ("on".equals(rule.getProperty("dependency")))
-		rpmBuilder.addDependencyMore("java", "1.6")
+		rpmBuilder.addDependencyMore("jre", "1.6")
 
 	rpmBuilder.setPostInstallScript("chkconfig --add kairosdb\nchkconfig kairosdb on")
 


### PR DESCRIPTION
Kairos only requires a jre to run.
Requiring java is overkill.
