### PR TITLE
fix nagative value maximum aggregators always return zero

### DIFF
--- a/src/main/java/org/kairosdb/core/aggregator/MaxAggregator.java
+++ b/src/main/java/org/kairosdb/core/aggregator/MaxAggregator.java
@@ -40,7 +40,7 @@ public class MaxAggregator extends RangeAggregator
 		@Override
 		public DataPoint getNextDataPoint(long returnTime, Iterator<DataPoint> dataPointRange)
 		{
-			double max = Double.MIN_VALUE;
+			double max = -Double.MAX_VALUE;
 			while (dataPointRange.hasNext())
 			{
 				max = Math.max(max, dataPointRange.next().getDoubleValue());


### PR DESCRIPTION
When trying to get maximum aggregators for nagative value metrics. Kairosdb will return 0. 
http://stackoverflow.com/questions/3884793/minimum-values-and-double-min-value-in-java 

Signed-off-by: pstan tanpinsiang@gmail.com
