### PR TITLE
Fix NullPointerException when importing data from early 1970

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -240,7 +240,7 @@ public class CassandraDatastore implements Datastore
 			for (DataPoint dp : dps.getDataPoints())
 			{
 				long newRowTime = calculateRowTime(dp.getTimestamp());
-				if (newRowTime != rowTime)
+				if (newRowTime != rowTime || rowKey == null)
 				{
 					rowTime = newRowTime;
 					rowKey = new DataPointsRowKey(dps.getName(), rowTime, dps.getTags());


### PR DESCRIPTION
Hello, I have found that importing data with very data point timestamp close to 0 triggers NullPointerException (see below).

I tracked the problem in the branch introduced comparison between newRowTime and rowTime... We don;t enter the branch if the rowTime is zero.
This branch also instanciates the rowKey object, therefore I modified the condition to enter the branch if the rowKey object has not yet been instanciated.

---

java.lang.NullPointerException
    at org.kairosdb.datastore.cassandra.DataPointsRowKeySerializer.toByteBuffer(DataPointsRowKeySerializer.java:32)
    at org.kairosdb.datastore.cassandra.DataPointsRowKeySerializer.toByteBuffer(DataPointsRowKeySerializer.java:24)
    at me.prettyprint.cassandra.service.BatchMutation.getInnerMutationMap(BatchMutation.java:131)
    at me.prettyprint.cassandra.service.BatchMutation.addMutation(BatchMutation.java:113)
    at me.prettyprint.cassandra.service.BatchMutation.addInsertion(BatchMutation.java:66)
    at me.prettyprint.cassandra.model.MutatorImpl.addInsertion(MutatorImpl.java:159)
    at org.kairosdb.datastore.cassandra.WriteBuffer.addData(WriteBuffer.java:84)
    at org.kairosdb.datastore.cassandra.CassandraDatastore.putDataPoints(CassandraDatastore.java:283)
    at org.kairosdb.core.datastore.KairosDatastore.putDataPoints(KairosDatastore.java:156)
    at org.kairosdb.core.Main.runImport(Main.java:332)
    at org.kairosdb.core.Main.main(Main.java:179)
