### PR TITLE
handle NumberFormatException by throwing a ValidationException

### DIFF
--- a/src/main/java/org/kairosdb/core/telnet/PutCommand.java
+++ b/src/main/java/org/kairosdb/core/telnet/PutCommand.java
@@ -62,13 +62,17 @@ public class PutCommand implements TelnetCommand, KairosMetricReporter
 		if (timestamp < 3000000000L)
 			timestamp *= 1000;
 
-		DataPoint dp;
-		if (command[3].contains("."))
-			dp = new DataPoint(timestamp, Double.parseDouble(command[3]));
-		else
-			dp = new DataPoint(timestamp, Util.parseLong(command[3]));
+        try {
+            DataPoint dp;
+            if (command[3].contains("."))
+                dp = new DataPoint(timestamp, Double.parseDouble(command[3]));
+            else
+                dp = new DataPoint(timestamp, Util.parseLong(command[3]));
+            dps.addDataPoint(dp);
 
-		dps.addDataPoint(dp);
+        } catch (NumberFormatException e) {
+            throw new ValidationException(e.getMessage());
+        }
 
 		int tagCount = 0;
 		for (int i = 4; i < command.length; i++)


### PR DESCRIPTION
without this malformed numbers (in our case "nan" coming from collectd python plugin) would result in a large stacktrace in the log file, with this exception wrapping it handles it quite nicely. I also think that ValidationException is fair to throw, although arguably one could add a Validator that makes sure all fields that are supposed to be numbers are in fact numbers.
let me know if you prefer this.
