### PR TITLE
Make flot tooltip show floating point for values where appropriate.

### DIFF
--- a/webroot/js/kairosdb-flot.js
+++ b/webroot/js/kairosdb-flot.js
@@ -72,8 +72,9 @@ function drawSingleSeriesChart(subTitle, data, flotOptions) {
 				var formattedDate = $.plot.formatDate(timestamp, "%b %e, %Y %H:%M:%S.millis %p");
 				formattedDate = formattedDate.replace("millis", timestamp.getMilliseconds());
 				formattedDate += " " + getTimezone(timestamp);
+				var numberFormat = (y % 1 != 0) ? '0,0[.00]' : '0,0';
 				showTooltip(item.pageX, item.pageY,
-					item.series.label + "<br>" + formattedDate + "<br>" + y);
+					item.series.label + "<br>" + formattedDate + "<br>" + numeral(y).format(numberFormat));
 			}
 		} else {
 			$("#tooltip").remove();


### PR DESCRIPTION
At present, the flot tooltip in the UI shows only the integer portion of data values.  This change makes the tooltip switch between floating point and integer format based on whether the value in question is an integer.
