### PR TITLE
Null Column Exception Caused by Invalid Tags reaching Write Buffer

### DIFF
--- a/src/main/java/org/kairosdb/core/http/MonitorFilter.java
+++ b/src/main/java/org/kairosdb/core/http/MonitorFilter.java
@@ -29,11 +29,15 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.kairosdb.util.Preconditions.checkNotNullOrEmpty;
 
 public class MonitorFilter implements Filter, KairosMetricReporter
 {
+    public static final Logger logger = LoggerFactory.getLogger(MonitorFilter.class);
+    
 	private final String hostname;
 	private final ConcurrentMap<String, AtomicInteger> counterMap = new ConcurrentHashMap<String, AtomicInteger>();
 
@@ -56,14 +60,19 @@ public class MonitorFilter implements Filter, KairosMetricReporter
 		if (index > -1)
 		{
 			String resourceName = path.substring(index + 1);
-			AtomicInteger counter = counterMap.get(resourceName);
-			if (counter == null)
+
+			//do not store empty method e.g. /api/v1/datapoints/<--- trailing slash
+			if (resourceName.length() > 0)
 			{
-				counter = new AtomicInteger();
-				AtomicInteger mapValue = counterMap.putIfAbsent(resourceName, counter);
-				counter = (mapValue != null ? mapValue : counter);
+				AtomicInteger counter = counterMap.get(resourceName);
+				if (counter == null)
+				{
+					counter = new AtomicInteger();
+					AtomicInteger mapValue = counterMap.putIfAbsent(resourceName, counter);
+					counter = (mapValue != null ? mapValue : counter);
+				}
+				counter.incrementAndGet();
 			}
-			counter.incrementAndGet();
 		}
 
 		filterChain.doFilter(servletRequest, servletResponse);

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -134,15 +134,15 @@ public class CassandraDatastore implements Datastore
 
 	@Inject
 	public CassandraDatastore(@Named(CassandraModule.CASSANDRA_AUTH_MAP) Map<String, String> cassandraAuthentication,
-	                          @Named(REPLICATION_FACTOR_PROPERTY) int replicationFactor,
-	                          @Named(SINGLE_ROW_READ_SIZE_PROPERTY) int singleRowReadSize,
-	                          @Named(MULTI_ROW_SIZE_PROPERTY) int multiRowSize,
-	                          @Named(MULTI_ROW_READ_SIZE_PROPERTY) int multiRowReadSize,
-	                          @Named(WRITE_DELAY_PROPERTY) int writeDelay,
-	                          @Named(WRITE_BUFFER_SIZE) int maxWriteSize,
-	                          final @Named("HOSTNAME") String hostname,
-			                    @Named(KEYSPACE_PROPERTY) String keyspaceName,
-	                          HectorConfiguration configuration) throws DatastoreException
+							  @Named(REPLICATION_FACTOR_PROPERTY) int replicationFactor,
+							  @Named(SINGLE_ROW_READ_SIZE_PROPERTY) int singleRowReadSize,
+							  @Named(MULTI_ROW_SIZE_PROPERTY) int multiRowSize,
+							  @Named(MULTI_ROW_READ_SIZE_PROPERTY) int multiRowReadSize,
+							  @Named(WRITE_DELAY_PROPERTY) int writeDelay,
+							  @Named(WRITE_BUFFER_SIZE) int maxWriteSize,
+							  final @Named("HOSTNAME") String hostname,
+								@Named(KEYSPACE_PROPERTY) String keyspaceName,
+							  HectorConfiguration configuration) throws DatastoreException
 	{
 		try
 		{
@@ -330,6 +330,12 @@ public class CassandraDatastore implements Datastore
 					//Write metric name if not in cache
 					if (!m_metricNameCache.isCached(dps.getName()))
 					{
+						if (dps.getName().length() == 0)
+						{
+							logger.warn(
+								"Attempted to add empty metric name to string index. Row looks like: "+dps
+							);
+						}
 						m_stringIndexWriteBuffer.addData(ROW_KEY_METRIC_NAMES,
 								dps.getName(), "", now);
 					}
@@ -340,6 +346,12 @@ public class CassandraDatastore implements Datastore
 					{
 						if (!m_tagNameCache.isCached(tagName))
 						{
+							if(tagName.length() == 0)
+							{
+								logger.warn(
+									"Attempted to add empty tagName to string cache for metric: "+dps.getName()
+								);
+							}
 							m_stringIndexWriteBuffer.addData(ROW_KEY_TAG_NAMES,
 									tagName, "", now);
 						}
@@ -347,6 +359,12 @@ public class CassandraDatastore implements Datastore
 						String value = tags.get(tagName);
 						if (!m_tagValueCache.isCached(value))
 						{
+							if(value.toString().length() == 0)
+							{
+								logger.warn(
+									"Attempted to add empty tagValue (tag name "+tagName+") to string cache for metric: "+dps.getName()
+								);
+							}
 							m_stringIndexWriteBuffer.addData(ROW_KEY_TAG_VALUES,
 									value, "", now);
 						}

--- a/src/main/java/org/kairosdb/datastore/cassandra/WriteBuffer.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/WriteBuffer.java
@@ -79,11 +79,18 @@ public class WriteBuffer<RowKeyType, ColumnKeyType, ValueType>  implements Runna
 		try
 		{
 			waitOnBufferFull();
-
 			m_bufferCount ++;
-			m_mutator.addInsertion(rowKey, m_cfName,
-					new HColumnImpl<ColumnKeyType, ValueType>(columnKey, value,
-							timestamp, m_columnKeySerializer, m_valueSerializer));
+
+			if (columnKey.toString().length() > 0) 
+			{
+				m_mutator.addInsertion(
+					rowKey,
+					m_cfName,
+					new HColumnImpl<ColumnKeyType, ValueType>(columnKey, value, timestamp, m_columnKeySerializer, m_valueSerializer)
+				);
+			} else {
+				logger.info("Discarded "+m_cfName+" row with empty column name. This should never happen.");
+			}
 		}
 		finally
 		{


### PR DESCRIPTION
When using Cassandra and the REST API if any client appends a trailing slash to their datapoints POST requests they will trigger an exception when the string_index write buffer is flushed. The sting index is updated as a result of the kairosdb.protocol.http_request_count metric being created with a blank value for it's method tag (see MonitorFilter).

```
[Thread-5] ERROR [WriteBuffer.java:201] - Error sending data to Cassandra
me.prettyprint.hector.api.exceptions.HInvalidRequestException: InvalidRequestException(why:column name must not be empty)
        at me.prettyprint.cassandra.service.ExceptionsTranslatorImpl.translate(ExceptionsTranslatorImpl.java:52) ~[hector-core-1.1-4.jar:na]
        at me.prettyprint.cassandra.connection.HConnectionManager.operateWithFailover(HConnectionManager.java:260) ~[hector-core-1.1-4.jar:na]
        at me.prettyprint.cassandra.model.ExecutingKeyspace.doExecuteOperation(ExecutingKeyspace.java:113) ~[hector-core-1.1-4.jar:na]
        at me.prettyprint.cassandra.model.MutatorImpl.execute(MutatorImpl.java:243) ~[hector-core-1.1-4.jar:na]
        at org.kairosdb.datastore.cassandra.WriteBuffer.run(WriteBuffer.java:195) ~[kairosdb.jar:0.9.3.20140116214226]
        at java.lang.Thread.run(Unknown Source) [na:1.7.0_45]
Caused by: org.apache.cassandra.thrift.InvalidRequestException: null
        at org.apache.cassandra.thrift.Cassandra$batch_mutate_result.read(Cassandra.java:20833) ~[cassandra-thrift-1.2.5.jar:1.2.5]
        at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:78) ~[libthrift-0.7.0.jar:0.7.0]
        at org.apache.cassandra.thrift.Cassandra$Client.recv_batch_mutate(Cassandra.java:964) ~[cassandra-thrift-1.2.5.jar:1.2.5]
        at org.apache.cassandra.thrift.Cassandra$Client.batch_mutate(Cassandra.java:950) ~[cassandra-thrift-1.2.5.jar:1.2.5]
        at me.prettyprint.cassandra.model.MutatorImpl$3.execute(MutatorImpl.java:246) ~[hector-core-1.1-4.jar:na]
        at me.prettyprint.cassandra.model.MutatorImpl$3.execute(MutatorImpl.java:243) ~[hector-core-1.1-4.jar:na]
        at me.prettyprint.cassandra.service.Operation.executeAndSetResult(Operation.java:104) ~[hector-core-1.1-4.jar:na]
        at me.prettyprint.cassandra.connection.HConnectionManager.operateWithFailover(HConnectionManager.java:253) ~[hector-core-1.1-4.jar:na]
        ... 4 common frames omitted
```

The fix prevents blank method tags from being added, adds additional debug information to show when something is attempting to insert invalid data into cassandra and discards any rows from the write buffer if they are not valid.
