### PR TITLE
Updated how to build instructions to use correct tablesaw version

### DIFF
--- a/how_to_build.txt
+++ b/how_to_build.txt
@@ -1,7 +1,7 @@
 Building requires JDK 1.6 or later.
 
 To build set your classpath to the tablesaw jar file like so:
->export CLASSPATH=tools/tablesaw-1.0.2.jar
+>export CLASSPATH=tools/tablesaw-1.0.4.jar
 
 Then to build type
 >java make


### PR DESCRIPTION
Tablesaw now at 1.0.4 instead of 1.0.2.
