### PR TITLE
Adjusted Cassandra consistency defaults for edgecases

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -102,7 +102,7 @@ public class CassandraDatastore implements Datastore
 
 	@Inject
 	@Named(WRITE_CONSISTENCY_LEVEL)
-	private ConsitencyLevel m_dataWriteLevel = ConsitencyLevel.ONE;
+	private ConsitencyLevel m_dataWriteLevel = ConsitencyLevel.QUORUM;
 
 	@Inject
 	@Named(READ_CONSISTENCY_LEVEL)

--- a/src/main/resources/kairosdb.properties
+++ b/src/main/resources/kairosdb.properties
@@ -64,7 +64,9 @@ kairosdb.datastore.cassandra.string_cache_size=5000
 # Uses Quartz Cron syntax - default is to run every five minutes
 kairosdb.datastore.cassandra.increase_buffer_size_schedule=0 */5 * * * ?
 
-# Controls the read and write consistency levels for cassandra operations
+#Control the required consistency for cassandra operations.
+#Available settings are cassandra version dependent:
+#http://www.datastax.com/documentation/cassandra/2.0/webhelp/index.html#cassandra/dml/dml_config_consistency_c.html
 kairosdb.datastore.cassandra.read_consistency_level=ONE
 kairosdb.datastore.cassandra.write_consistency_level=QUORUM
 


### PR DESCRIPTION
If anyone updates their kairos version to include the global cassandra consistency levels change but does not update their config (default rpm behaviour) they should keep QUORUM consistency for writes instead of falling back to ONE.
This is necessary because of the change to the config key name for consistency. 

Also updated config to include docs on consistency levels.
