### PR TITLE
Support other whitespace in WordSplitter

### DIFF
--- a/src/main/java/org/kairosdb/core/telnet/WordSplitter.java
+++ b/src/main/java/org/kairosdb/core/telnet/WordSplitter.java
@@ -42,22 +42,21 @@ public class WordSplitter extends OneToOneDecoder
 		return splitString(((ChannelBuffer) msg).toString(CHARSET));
 	}
 
-	private String[] splitString(final String s)
+	protected static String[] splitString(final String s)
 	{
-		final char c = ' ';
-
 		final char[] chars = s.trim().toCharArray();
-		int num_substrings = 1;
-		char last = 'A';
+		int num_substrings = 0;
+		boolean last_was_space = true;
 		for (final char x : chars)
 		{
-			if (x == c)
+			if (Character.isWhitespace(x))
+			    last_was_space = true;
+			else
 			{
-				if (x != last) //skip double whitespace
+				if (last_was_space)
 					num_substrings++;
+				last_was_space = false;
 			}
-
-			last = x;
 		}
 
 		final String[] result = new String[num_substrings];
@@ -65,20 +64,24 @@ public class WordSplitter extends OneToOneDecoder
 		int start = 0;  // starting index in chars of the current substring.
 		int pos = 0;    // current index in chars.
 		int i = 0;      // number of the current substring.
-		last = 'A';
+		last_was_space = true;
 		for (; pos < len; pos++)
 		{
-			if (chars[pos] == c)
+			if (Character.isWhitespace(chars[pos]))
 			{
-				if (chars[pos] != last)
+				if (!last_was_space)
 					result[i++] = new String(chars, start, pos - start);
-
-				start = pos + 1;
+				last_was_space = true;
 			}
-
-			last = chars[pos];
+			else
+			{
+				if (last_was_space)
+					start = pos;
+				last_was_space = false;
+			}
 		}
-		result[i] = new String(chars, start, pos - start);
+		if (!last_was_space)
+			result[i] = new String(chars, start, pos - start);
 		return result;
 	}
 }

--- a/src/test/java/org/kairosdb/core/telnet/WordSplitterTest.java
+++ b/src/test/java/org/kairosdb/core/telnet/WordSplitterTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013 Proofpoint Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.kairosdb.core.telnet;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+
+public class WordSplitterTest
+{
+	private WordSplitter wordsplitter;
+
+	@Test
+	public void test()
+	{
+		assertArrayEquals(new String[]{"simple", "white", "space", "string"},
+		                  wordsplitter.splitString("simple white space string"));
+		assertArrayEquals(new String[]{"uses", "tab", "separators"},
+		                  wordsplitter.splitString("uses\ttab\tseparators"));
+		assertArrayEquals(new String[]{},
+		                  wordsplitter.splitString(""));  // empty string
+		assertArrayEquals(new String[]{},
+		                  wordsplitter.splitString("  \t  \t"));  // only spaces
+		assertArrayEquals(new String[]{"multiple", "interstitial", "space", "chars"},
+		                  wordsplitter.splitString("multiple \tinterstitial\t space \t chars"));
+		assertArrayEquals(new String[]{"space", "at", "start"},
+		                  wordsplitter.splitString("  space at start"));
+		assertArrayEquals(new String[]{"space", "at", "end"},
+		                  wordsplitter.splitString("space at end  "));
+		assertArrayEquals(new String[]{"space", "at", "start", "and", "end"},
+		                  wordsplitter.splitString("  space at start and end  "));
+		assertArrayEquals(new String[]{"nospace"},
+		                  wordsplitter.splitString("nospace"));
+	}
+}


### PR DESCRIPTION
Our Carbon setup at work, some of which is custom-built, typically uses
tabs and not spaces in the Carbon plaintext protocol. The stock Carbon
daemons are fine with this, as are some related tools like
graph-explorer.

However, Kairos's carbon server only accepts spaces, and throws
exceptions for every received line using tabs. This change makes it
split strings on any (iso-8859-1) whitespace characters without
sacrificing much of the speed improvement over String.split() or
Pattern.split(). It also allows leading or trailing whitespace on input
lines.

As far as I can tell, this does not break any other uses of
the WordSplitter class.
