### PR TITLE
Startup script minor update for cygwin

### DIFF
--- a/src/scripts/kairosdb.sh
+++ b/src/scripts/kairosdb.sh
@@ -30,7 +30,11 @@ fi
 # Load up the classpath
 CLASSPATH="conf/logging"
 for jar in $KAIROSDB_LIB_DIR/*.jar; do
-	CLASSPATH="$CLASSPATH:$jar"
+	if [[ `uname` =~ "CYGWIN" ]] ; then
+		CLASSPATH="$CLASSPATH;$jar"
+	else 
+		CLASSPATH="$CLASSPATH:$jar"
+	fi
 done
 
 


### PR DESCRIPTION
Just a simple modification with a variable path separator. 
Using this minor modification the kairosdb.sh script works on Cygwin as well as on Unix/Linux systems.
