### PR TITLE
Return query in response

### DIFF
--- a/src/main/java/org/kairosdb/core/datastore/QueryMetric.java
+++ b/src/main/java/org/kairosdb/core/datastore/QueryMetric.java
@@ -15,18 +15,17 @@
  */
 package org.kairosdb.core.datastore;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
-import org.kairosdb.core.aggregator.Aggregator;
-import org.kairosdb.core.groupby.GroupBy;
-import org.kairosdb.util.Preconditions;
-
+import com.google.gson.JsonObject;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.kairosdb.core.aggregator.Aggregator;
+import org.kairosdb.core.groupby.GroupBy;
+import org.kairosdb.util.Preconditions;
 
 public class QueryMetric implements DatastoreMetricQuery
 {
@@ -41,6 +40,7 @@ public class QueryMetric implements DatastoreMetricQuery
 	private boolean excludeTags = false;
 	private int limit;
 	private Order order = Order.ASC;
+        private JsonObject query;
 
 	public QueryMetric(long start_time, int cacheTime, String name)
 	{
@@ -84,6 +84,15 @@ public class QueryMetric implements DatastoreMetricQuery
 
 	return this;
 	}
+
+        public void setQueryObject(JsonObject query){
+            this.query = query;
+        }
+        
+        public JsonObject getQueryObject(){
+            return query;
+        }
+        
 
 	public QueryMetric addTag(String name, String value)
 	{

--- a/src/main/java/org/kairosdb/core/formatter/JsonResponse.java
+++ b/src/main/java/org/kairosdb/core/formatter/JsonResponse.java
@@ -55,6 +55,7 @@ public class JsonResponse
 
 	/**
 	 * Formats the query results
+         * Used when querying for meta data.
 	 *
 	 * @param queryResults results of the query
 	 * @param excludeTags if true do not include tag information
@@ -150,7 +151,9 @@ public class JsonResponse
         
         
         /**
-	 * Formats the query results
+	 * Formats the query results.
+         * This writes the query into the response Json. 
+         * Useful when querying multiple times for the same metric with different aggregators.
 	 *
 	 * @param queryResults results of the query
 	 * @param excludeTags if true do not include tag information

--- a/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
+++ b/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
@@ -337,7 +337,7 @@ public class MetricsResource implements KairosMetricReporter
 				try
 				{
 					List<DataPointGroup> results = dq.execute();
-					jsonResponse.formatQuery(results, query.isExcludeTags(), dq.getSampleSize());
+					jsonResponse.formatQuery(results, query.isExcludeTags(), query.getQueryObject(), dq.getSampleSize());
 
 					ThreadReporter.addDataPoint(QUERY_TIME, System.currentTimeMillis() - startQuery);
 				}

--- a/src/main/java/org/kairosdb/core/http/rest/json/GsonParser.java
+++ b/src/main/java/org/kairosdb/core/http/rest/json/GsonParser.java
@@ -175,7 +175,7 @@ public class GsonParser
 						metric.getName());
 				queryMetric.setExcludeTags(metric.isExcludeTags());
 				queryMetric.setLimit(metric.getLimit());
-
+                                queryMetric.setQueryObject(metricsArray.get(I).getAsJsonObject());
 				long endTime = getEndTime(query);
 				if (endTime > -1)
 					queryMetric.setEndTime(endTime);

--- a/src/test/java/org/kairosdb/core/formatter/JsonResponseTest.java
+++ b/src/test/java/org/kairosdb/core/formatter/JsonResponseTest.java
@@ -17,6 +17,7 @@ package org.kairosdb.core.formatter;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Resources;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.junit.Before;
@@ -65,7 +66,7 @@ public class JsonResponseTest
 		group1.addDataPoint(new LongDataPoint(56789, 2));
 		group1.addDataPoint(new DoubleDataPoint(98765, 2.9));
 
-		ListDataPointGroup group2 = new ListDataPointGroup("metric2");
+		ListDataPointGroup group2 = new ListDataPointGroup("metric1");
 		group2.addTag("tag3", "value3");
 		group2.addTag("tag4", "value4");
 		group2.addGroupByResult(groupBy.getGroupByResult(1));
@@ -75,9 +76,31 @@ public class JsonResponseTest
 
 		groups.add(group1);
 		groups.add(group2);
+                
+                JsonObject queryObject = new JsonObject();
+                queryObject.addProperty("name", "metric1");
+                queryObject.add("tags", new JsonObject());
+                // groupBy
+                JsonArray groupBys = new JsonArray();
+                JsonObject groupByValue = new JsonObject();
+                groupByValue.addProperty("name", "value");
+                groupByValue.addProperty("range_size", "10");
+                groupBys.add(groupByValue);
+                queryObject.add("group_by", groupBys);
+                // aggregators
+                JsonArray aggregators = new JsonArray();
+                JsonObject sumaggregator = new JsonObject();
+                sumaggregator.addProperty("name", "sum");
+                sumaggregator.addProperty("align_sampling", true);
+                JsonObject sampling = new JsonObject();
+                sampling.addProperty("value", "1");
+                sampling.addProperty("unit", "milliseconds");
+                sumaggregator.add("sampling", sampling);
+                aggregators.add(sumaggregator);
+                queryObject.add("aggregators", aggregators);
 
 		response.begin();
-		response.formatQuery(groups, false, 10);
+		response.formatQuery(groups, false,queryObject, 10);
 		response.end();
 
 		assertJson(writer.toString(), json);

--- a/src/test/resources/query-response-two-groups-valid.json
+++ b/src/test/resources/query-response-two-groups-valid.json
@@ -2,6 +2,27 @@
 	"queries": [
 		{
             "sample_size": 10,
+			"query":{
+				"name": "metric1",
+				"tags":{},
+				"group_by":[
+					{
+						"name":"value",
+						"range_size":"10"
+					}
+				],
+				"aggregators":[
+					{
+						"name":"sum",
+						"align_sampling":true,
+						"sampling":
+							{
+								"value":"1",
+								"unit":"milliseconds"
+							}
+					}
+				]
+			},
 			"results": [
 				{
 					"name": "metric1",
@@ -21,7 +42,7 @@
 					"values": [[12345, 1 ], [56789, 2], [98765, 2.9]]
 				},
 				{
-					"name": "metric2",
+					"name": "metric1",
 					"group_by": [
 						{
 							"name": "value",

--- a/webroot/js/graph.js
+++ b/webroot/js/graph.js
@@ -695,6 +695,26 @@ function showChart(subTitle, queries, metricData) {
 		}
 
 		sampleSize += resultSet.sample_size;
+                var aggregatorList = "";
+                if(resultSet.query && resultSet.query.aggregators){
+                    $.each(resultSet.query.aggregators,function (index,aggregator) {
+                        if(aggregatorList) aggregatorList += "|";
+                        else aggregatorList = ":";
+                        aggregatorList+= aggregator.name;
+                        if(aggregator.sampling)
+                            aggregatorList+='('+aggregator.sampling.value+aggregator.sampling.unit+')';
+                        else if(aggregator.unit)
+                            aggregatorList+='('+aggregator.unit+')';
+                        else if(aggregator.factor)
+                            aggregatorList+='('+aggregator.factor+')';
+                        else if(aggregator.divisor)
+                            aggregatorList+='('+aggregator.divisor+')';
+                    });
+                }
+                
+                
+                
+                
 		resultSet.results.forEach(function (queryResult) {
 
 			var groupByMessage = "";
@@ -728,8 +748,8 @@ function showChart(subTitle, queries, metricData) {
 				return;
 
 			var result = {};
-			result.name = queryResult.name + groupByMessage;
-			result.label = queryResult.name + groupByMessage;
+			result.name = queryResult.name + aggregatorList + groupByMessage;
+			result.label = queryResult.name + aggregatorList + groupByMessage;
 			result.data = queryResult.values;
 			result.yaxis = axisCount; // Flot
 			result.yAxis = axisCount - 1; // Highcharts


### PR DESCRIPTION
Hi,
This adds a little bit of overhead to every query response, but it is very useful when issuing multiple queries. Indeed in the current version it is impossible to distinguish responses if queries are made to the same metric, but with different aggregators.