### PR TITLE
Allow more configuration of local bind addresses

### DIFF
--- a/src/main/resources/kairosdb.properties
+++ b/src/main/resources/kairosdb.properties
@@ -1,4 +1,5 @@
 kairosdb.telnetserver.port=4242
+kairosdb.telnetserver.address=0.0.0.0
 
 kairosdb.service.telnet=org.kairosdb.core.telnet.TelnetServerModule
 kairosdb.service.http=org.kairosdb.core.http.WebServletModule

--- a/src/main/resources/kairosdb.properties
+++ b/src/main/resources/kairosdb.properties
@@ -140,7 +140,9 @@ kairosdb.query_cache.cache_file_cleaner_schedule=0 0 12 ? * SUN *
 #kairosdb.service.carbon=org.kairosdb.core.carbon.CarbonServerModule
 kairosdb.carbon.tagparser=org.kairosdb.core.carbon.HostTagParser
 kairosdb.carbon.text.port=2003
+kairosdb.carbon.text.address=0.0.0.0
 kairosdb.carbon.pickle.port=2004
+kairosdb.carbon.pickle.address=0.0.0.0
 
 #Determins the size of the buffer to allocate for incoming pickles
 kairosdb.carbon.pickle.max_size=2048

--- a/src/main/resources/kairosdb.properties
+++ b/src/main/resources/kairosdb.properties
@@ -25,6 +25,7 @@ kairosdb.reporter.schedule=0 */1 * * * ?
 #===============================================================================
 # Set to 0 to turn off HTTP port
 kairosdb.jetty.port=8080
+kairosdb.jetty.address=0.0.0.0
 kairosdb.jetty.static_web_root=webroot
 
 # To enable SSL uncomment the following lines and specify the path to the keyStore and its password and port


### PR DESCRIPTION
KairosDB listens on some ports : 
- Telnet server (default port 4242)
- HTTP / Web Servlet (default port 8080)
- Carbon Text (default port 2003)
- Carbon Pickle (default port 2004)

We would like to allow more configuration of the local bind address : 
- Choosing the local IP address (by default, like now: 0.0.0.0 = all addresses, but also adding possibility to bind on 127.0.0.1 or on a specific IP address of the server)
- Be compatible with IPv6 addresses

In that case, we would need to introduce new configuration settings, here is a proposal: 
- kairosdb.telnetserver.address
- kairosdb.jetty.address /  kairosdb.jetty.ssl.address
- kairosdb.carbon.text.address
- kairosdb.carbon.pickle.address

We would need to support:
- hostnames (like : 'localhost', 'localhost.localdomain', 'my.host.name'
- IPv4 addresses like '0.0.0.0' (all addresses), '127.0.0.x' (loopback), 'x.y.z.t', ...
- IPv6 addresses like '0:0:0:0:0:0:0:0' or '::' (all addresses), '::1' (loopback), ...