### PR TITLE
Add configurable CharacterSet validation regex pattern

### DIFF
--- a/src/main/java/org/kairosdb/util/CharacterSet.java
+++ b/src/main/java/org/kairosdb/util/CharacterSet.java
@@ -15,25 +15,82 @@
  */
 package org.kairosdb.util;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class CharacterSet
 {
-	private static final Pattern regex = Pattern.compile("^[a-zA-Z0-9\\-\\./_]*$");
+  private static final Logger log = LoggerFactory.getLogger(CharacterSet.class);
 
-	private CharacterSet()
-	{
-	}
+  private static final String CHARACTER_SET_REGEX_PATTERN = "kairosdb.character.set.regex.pattern";
+  private static CharacterSet internalCharacterSet;
+  private Pattern regex;
 
-	/**
-	 * Returns true if the specified string contains a valid set of characters
-	 * @param s string to test
-	 * @return true if all characters in the string are valid
-	 */
-	public static boolean isValid(String s)
-	{
-		Matcher matcher = regex.matcher(s);
-		return matcher.matches();
-	}
+  private CharacterSet()
+  {
+  }
+
+  /**
+   * Static wrapper for internal version of isValid
+   */
+  public static boolean isValid(String s)
+  {
+    return provideInternalCharacterSet().isValidInternal(s);
+  }
+
+  /**
+   * Returns true if the specified string contains a valid set of characters
+   * @param s string to test
+   * @return true if all characters in the string are valid
+   */
+  private boolean isValidInternal(String s)
+  {
+    Matcher matcher = regex.matcher(s);
+    return matcher.matches();
+  }
+
+  /**
+   * Provides a static CharacterSet, which is used by isValid.
+   * Creates a new CharacterSet object only on first pass.
+   * @return the static CharacterSet
+   */
+  private static CharacterSet provideInternalCharacterSet() {
+    if (internalCharacterSet == null) {
+      internalCharacterSet = newCharacterSet();
+    }
+    return internalCharacterSet;
+  }
+
+  /**
+   * Factory method for creating a CharacterSet object with a configurable pattern
+   */
+  private static CharacterSet newCharacterSet() {
+    CharacterSet cs = new CharacterSet();
+    try {
+      cs.setPatternFromConfig();
+    } catch (IOException ex) {
+      // ignore for now
+    }
+    return cs;
+  }
+
+  /**
+   * Read the regex pattern for validation from kairosdb.properties file and set
+   */
+  private void setPatternFromConfig() throws IOException {
+    Properties props = new Properties();
+    InputStream is = getClass().getClassLoader().getResourceAsStream("kairosdb.properties");
+    props.load(is);
+    is.close();
+
+    String regexPattern = props.getProperty(CHARACTER_SET_REGEX_PATTERN);
+    log.info("CharacterSet validation regex pattern: {}", regexPattern);
+    regex = Pattern.compile(regexPattern);
+  }
 }

--- a/src/main/resources/kairosdb.properties
+++ b/src/main/resources/kairosdb.properties
@@ -173,3 +173,7 @@ kairosdb.carbon.hosttagparser.metric_replacement=$1.$2
 #kairosdb.datastore.cassandra.hector.maxLastSuccessTimeMillis-1
 
 #===============================================================================
+# Character validation regex
+kairosdb.character.set.regex.pattern=^[a-zA-Z0-9\\-\\./_]*$
+
+#===============================================================================


### PR DESCRIPTION
I'm facing a situation where we need to support characters beyond the traditional "^[a-zA-Z0-9\-\./_]*$" regex pattern. Yeah, I can easily hard code a custom change, but it would be really nice to make it configurable. I see that this has been a pain point in the past, so I figured I would take a stab at making it configurable through the kairosdb.properties file. I tried to localize the changes to only CharacterSet.java so that there weren't too many moving pieces.

I'm totally open to feedback here! I realize this solution may not match up with everyone's vision for the code. Maybe we can hammer this into something we all agree on?

The unit tests I've run still pass, but not a few were not even passing when I forked the repo before I made code changes. I also did some manual testing with the in-memory store to verify I could send and query data. I'm sure there is more exhaustive testing that can be done, especially against Cassandra, which is our use case.
