### PR TITLE
Quick fix #101 use Consistency Level from properties file

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -107,15 +107,10 @@ public class CassandraDatastore implements Datastore
 
 	@Inject
 	private LongDataPointFactory m_longDataPointFactory = new LongDataPointFactoryImpl();
+	
+	private final ConsistencyLevel m_dataWriteLevel;
 
-	@Inject
-	@Named(WRITE_CONSISTENCY_LEVEL)
-	private ConsitencyLevel m_dataWriteLevel = ConsitencyLevel.QUORUM;
-
-	@Inject
-	@Named(READ_CONSISTENCY_LEVEL)
-	private ConsitencyLevel m_dataReadLevel = ConsitencyLevel.ONE;
-
+	private final ConsistencyLevel m_dataReadLevel;
 	
 	@Inject(optional=true)
 	@Named(DATAPOINT_TTL)
@@ -144,9 +139,11 @@ public class CassandraDatastore implements Datastore
 	                          @Named(WRITE_DELAY_PROPERTY) int writeDelay,
 	                          @Named(WRITE_BUFFER_SIZE) int maxWriteSize,
 	                          final @Named("HOSTNAME") String hostname,
-                             @Named(KEYSPACE_PROPERTY) String keyspaceName,
+                              @Named(KEYSPACE_PROPERTY) String keyspaceName,
+                              @Named(WRITE_CONSISTENCY_LEVEL) ConsistencyLevel dataWriteLevel,
+                              @Named(READ_CONSISTENCY_LEVEL) ConsistencyLevel dataReadLevel,
 	                          HectorConfiguration configuration,
-                             KairosDataPointFactory kairosDataPointFactory) throws DatastoreException
+                              KairosDataPointFactory kairosDataPointFactory) throws DatastoreException
 	{
 		try
 		{
@@ -155,6 +152,9 @@ public class CassandraDatastore implements Datastore
 			m_multiRowReadSize = multiRowReadSize;
 			m_kairosDataPointFactory = kairosDataPointFactory;
 			m_keyspaceName = keyspaceName;
+
+			m_dataWriteLevel = dataWriteLevel;
+			m_dataReadLevel = dataReadLevel;
 
 			CassandraHostConfigurator hostConfig = configuration.getConfiguration();
 

--- a/src/main/java/org/kairosdb/datastore/cassandra/ConsistencyLevel.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/ConsistencyLevel.java
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2013 Proofpoint Inc.
  *
@@ -25,7 +26,7 @@ import me.prettyprint.hector.api.HConsistencyLevel;
  Time: 8:42 AM
  To change this template use File | Settings | File Templates.
  */
-public enum ConsitencyLevel
+public enum ConsistencyLevel
 {
 	ANY (HConsistencyLevel.ANY),
 	ONE (HConsistencyLevel.ONE),
@@ -38,7 +39,7 @@ public enum ConsitencyLevel
 
 	private final HConsistencyLevel m_level;
 
-	ConsitencyLevel(HConsistencyLevel level)
+	ConsistencyLevel(HConsistencyLevel level)
 	{
 		m_level = level;
 	}


### PR DESCRIPTION
Fixing consistency level not being read from config file, using constructor injection should fix this.
