### PR TITLE
fixing up path to carbon

### DIFF
--- a/src/main/resources/kairosdb.properties
+++ b/src/main/resources/kairosdb.properties
@@ -132,9 +132,11 @@ kairosdb.query_cache.cache_file_cleaner_schedule=0 0 12 ? * SUN *
 #===============================================================================
 # Settings for the carbon server protocol handler
 #Turn the carbon endpoint on by uncommenting the following line
-#kairosdb.service.carbon=org.kairosdb.core.carbon.CarbonServerModule
-kairosdb.carbon.tagparser=org.kairosdb.core.carbon.HostTagParser
+#kairosdb.service.carbon=org.kairosdb.plugin.carbon.CarbonServerModule
+kairosdb.carbon.tagparser=org.kairosdb.plugin.carbon.HostTagParser
+kairosdb.carbon.text.address=0.0.0.0
 kairosdb.carbon.text.port=2003
+kairosdb.carbon.pickle.address=0.0.0.0
 kairosdb.carbon.pickle.port=2004
 
 #Determins the size of the buffer to allocate for incoming pickles


### PR DESCRIPTION
Updating example properties file to reflect that carbon is a plugin and not core.
Adding example config for specifying listen address for carbon/pickle.
