### PR TITLE
Add configurable dropwizard metrics to be sent to a graphite server

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -90,5 +90,10 @@
 
 		<dependency org="org.testng" name="testng" rev="6.8.5" conf="integration->default"/>
 
-	</dependencies>
+        <!-- Metrics -->
+        <dependency org="io.dropwizard.metrics" name="metrics-core" rev="3.1.0" />
+        <dependency org="io.dropwizard.metrics" name="metrics-graphite" rev="3.1.0" />
+        <dependency org="io.dropwizard.metrics" name="metrics-jvm" rev="3.1.0" />
+
+    </dependencies>
 </ivy-module>

--- a/src/main/java/org/kairosdb/util/InternalMetricsServer.java
+++ b/src/main/java/org/kairosdb/util/InternalMetricsServer.java
@@ -1,0 +1,121 @@
+package org.kairosdb.util;
+
+import ch.qos.logback.classic.Logger;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.graphite.Graphite;
+import com.codahale.metrics.graphite.GraphiteReporter;
+import com.codahale.metrics.jvm.*;
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import org.kairosdb.core.KairosDBService;
+import org.kairosdb.core.exception.KairosDBException;
+import org.slf4j.LoggerFactory;
+
+import java.lang.management.ManagementFactory;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by irinaguberman on 12/8/14.
+ */
+public class InternalMetricsServer implements KairosDBService {
+
+    public static final String GRAPHITE_HOST = "kairosdb.internal.graphite.host";
+    public static final String GRAPHITE_PORT = "kairosdb.internal.graphite.port";
+    public static final String GRAPHITE_INTERVAL = "kairosdb.internal.graphite.interval";
+    public static final String GRAPHITE_TIME_UNIT = "kairosdb.internal.graphite.timeUnit";
+
+    public static final String METRIC_GC = "kairosdb.internal.metric.gc";
+    public static final String METRIC_BP = "kairosdb.internal.metric.bufferPool";
+    public static final String METRIC_CACHED_TS = "kairosdb.internal.metric.cachedThreadStates";
+    public static final String METRIC_FD_RATIO = "kairosdb.internal.metric.fdRatio";
+    public static final String METRIC_MEM_USAGE = "kairosdb.internal.metric.memUsage";
+    public static final String METRIC_CL = "kairosdb.internal.metric.classLoading";
+    public static final String METRIC_TS = "kairosdb.internal.metric.threadStates";
+
+    private Graphite graphite;
+    private GraphiteReporter reporter;
+
+    public static final Logger logger = (Logger) LoggerFactory.getLogger(InternalMetricsServer.class);
+
+    @Inject
+    public InternalMetricsServer(@Named(GRAPHITE_HOST) String hostname,
+                                 @Named(GRAPHITE_PORT) int port,
+                                 @Named(GRAPHITE_INTERVAL) int interval,
+                                 @Named(GRAPHITE_TIME_UNIT) TimeUnit timeUnit,
+                                 @Named(METRIC_GC) boolean gc,
+                                 @Named(METRIC_BP) boolean bp,
+                                 @Named(METRIC_CACHED_TS) boolean cachedTS,
+                                 @Named(METRIC_FD_RATIO) boolean fdRatio,
+                                 @Named(METRIC_MEM_USAGE) boolean memUsage,
+                                 @Named(METRIC_CL) boolean cl,
+                                 @Named(METRIC_TS) boolean ts){
+        logger.warn("Constructing InternalMetricsServer with ".concat(hostname));
+        if(hostname != null && hostname.length() > 0) {
+            graphite = new Graphite(hostname, port);
+            init_internal_metrics(interval, timeUnit,
+                    gc, bp, cachedTS, fdRatio, memUsage, cl, ts);
+        }
+        else{
+           logger.info("NOT starting internal metrics Graphite host is not set!");
+        }
+    }
+
+
+    private void init_internal_metrics(Integer interval, TimeUnit timeUnit,
+                                       boolean gc,
+                                       boolean bp,
+                                       boolean cachedTS,
+                                       boolean fdRatio,
+                                       boolean memUsage,
+                                       boolean cl,
+                                       boolean ts){
+        logger.info("Starting internal metrics with interval {} and timeUnit {}", interval, timeUnit);
+
+        com.codahale.metrics.MetricRegistry metrics = new MetricRegistry();
+
+        if (bp) {
+            metrics.register("buffer_pool", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
+        }
+        else{
+            logger.info("Buffer_pool is OFF!!!");
+        }
+
+        if(cachedTS) {
+            metrics.register("cached_thread_states", new CachedThreadStatesGaugeSet(interval, timeUnit));
+        }
+        if(cl){
+            metrics.register("class_loading", new ClassLoadingGaugeSet());
+        }
+
+        if(fdRatio){
+            metrics.register("file_descriptor_ratio", new FileDescriptorRatioGauge());
+        }
+        if(gc){
+            metrics.register("GC", new GarbageCollectorMetricSet());
+        }
+        if(memUsage){
+            metrics.register("mem_usage", new MemoryUsageGaugeSet());
+        }
+        if(ts){
+            metrics.register("thread_states", new ThreadStatesGaugeSet());
+        }
+
+        reporter = GraphiteReporter.forRegistry(metrics)
+                .prefixedWith("ubic")
+                .convertRatesTo(TimeUnit.SECONDS)
+                .convertDurationsTo(TimeUnit.MILLISECONDS)
+                .filter(MetricFilter.ALL)
+                .build(graphite);
+    }
+
+    @Override
+    public void start() throws KairosDBException {
+        reporter.start(1, TimeUnit.MINUTES);
+    }
+
+    @Override
+    public void stop() {
+        reporter.stop();
+    }
+}

--- a/src/main/java/org/kairosdb/util/InternalMetricsServer.java
+++ b/src/main/java/org/kairosdb/util/InternalMetricsServer.java
@@ -25,6 +25,7 @@ public class InternalMetricsServer implements KairosDBService {
     public static final String GRAPHITE_INTERVAL = "kairosdb.internal.graphite.interval";
     public static final String GRAPHITE_TIME_UNIT = "kairosdb.internal.graphite.timeUnit";
 
+    public static final String METRIC_PREFIX = "kairosdb.internal.metric.prefix";
     public static final String METRIC_GC = "kairosdb.internal.metric.gc";
     public static final String METRIC_BP = "kairosdb.internal.metric.bufferPool";
     public static final String METRIC_CACHED_TS = "kairosdb.internal.metric.cachedThreadStates";
@@ -43,6 +44,7 @@ public class InternalMetricsServer implements KairosDBService {
                                  @Named(GRAPHITE_PORT) int port,
                                  @Named(GRAPHITE_INTERVAL) int interval,
                                  @Named(GRAPHITE_TIME_UNIT) TimeUnit timeUnit,
+                                 @Named(METRIC_PREFIX) String metricPrefix,
                                  @Named(METRIC_GC) boolean gc,
                                  @Named(METRIC_BP) boolean bp,
                                  @Named(METRIC_CACHED_TS) boolean cachedTS,
@@ -53,7 +55,7 @@ public class InternalMetricsServer implements KairosDBService {
         logger.warn("Constructing InternalMetricsServer with ".concat(hostname));
         if(hostname != null && hostname.length() > 0) {
             graphite = new Graphite(hostname, port);
-            init_internal_metrics(interval, timeUnit,
+            init_internal_metrics(interval, timeUnit, metricPrefix,
                     gc, bp, cachedTS, fdRatio, memUsage, cl, ts);
         }
         else{
@@ -62,7 +64,7 @@ public class InternalMetricsServer implements KairosDBService {
     }
 
 
-    private void init_internal_metrics(Integer interval, TimeUnit timeUnit,
+    private void init_internal_metrics(Integer interval, TimeUnit timeUnit, String metricPrefix,
                                        boolean gc,
                                        boolean bp,
                                        boolean cachedTS,
@@ -102,7 +104,7 @@ public class InternalMetricsServer implements KairosDBService {
         }
 
         reporter = GraphiteReporter.forRegistry(metrics)
-                .prefixedWith("ubic")
+                .prefixedWith(metricPrefix)
                 .convertRatesTo(TimeUnit.SECONDS)
                 .convertDurationsTo(TimeUnit.MILLISECONDS)
                 .filter(MetricFilter.ALL)

--- a/src/main/java/org/kairosdb/util/InternalMetricsServerModule.java
+++ b/src/main/java/org/kairosdb/util/InternalMetricsServerModule.java
@@ -26,7 +26,6 @@ public class InternalMetricsServerModule extends AbstractModule
         {
             logger.info("Configuring module InternalMetricsServerModule");
 
-            System.out.println("Binding InternalMetricsServer NOW!!!");
             bind(InternalMetricsServer.class).in(Singleton.class);
         }
     }

--- a/src/main/java/org/kairosdb/util/InternalMetricsServerModule.java
+++ b/src/main/java/org/kairosdb/util/InternalMetricsServerModule.java
@@ -1,0 +1,32 @@
+package org.kairosdb.util;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Singleton;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+/**
+ * Created by irinaguberman on 12/18/14.
+ */
+public class InternalMetricsServerModule extends AbstractModule
+    {
+        public static final Logger logger = LoggerFactory.getLogger(InternalMetricsServerModule.class);
+
+        private Properties m_props;
+
+        public InternalMetricsServerModule(Properties props)
+        {
+            m_props = props;
+        }
+
+        @Override
+        protected void configure()
+        {
+            logger.info("Configuring module InternalMetricsServerModule");
+
+            System.out.println("Binding InternalMetricsServer NOW!!!");
+            bind(InternalMetricsServer.class).in(Singleton.class);
+        }
+    }

--- a/src/main/resources/kairosdb.properties
+++ b/src/main/resources/kairosdb.properties
@@ -173,3 +173,22 @@ kairosdb.carbon.hosttagparser.metric_replacement=$1.$2
 #kairosdb.datastore.cassandra.hector.maxLastSuccessTimeMillis-1
 
 #===============================================================================
+
+# Internal-metrics-to-graphite configuration
+
+kairosdb.service.internal.metrics=org.kairosdb.util.InternalMetricsServerModule
+kairosdb.internal.graphite.host=localhost
+kairosdb.internal.graphite.port=2003
+
+kairosdb.internal.graphite.interval=10
+kairosdb.internal.graphite.timeUnit=SECONDS
+
+kairosdb.internal.metric.gc=true
+kairosdb.internal.metric.bufferPool=true
+kairosdb.internal.metric.cachedThreadStates=true
+kairosdb.internal.metric.fdRatio=true
+kairosdb.internal.metric.memUsage=true
+kairosdb.internal.metric.classLoading=true
+kairosdb.internal.metric.threadStates=true
+
+#===============================================================================

--- a/src/main/resources/kairosdb.properties
+++ b/src/main/resources/kairosdb.properties
@@ -183,6 +183,7 @@ kairosdb.internal.graphite.port=2003
 kairosdb.internal.graphite.interval=10
 kairosdb.internal.graphite.timeUnit=SECONDS
 
+kairosdb.internal.metric.prefix=my_prefix
 kairosdb.internal.metric.gc=true
 kairosdb.internal.metric.bufferPool=true
 kairosdb.internal.metric.cachedThreadStates=true


### PR DESCRIPTION
This functionality  is added for troubleshooting/monitoring kairosdb process itself.  This code allows sending various JVM metrics to a graphite server using dropwizard library.    Internal metrics will only work if the Internal-metrics-to-graphite configuration section is present and has graphite host configured.   Also various JVM metrics can be switched on and off.   
