### PR TITLE
fix: export csv

### DIFF
--- a/webroot/js/dataExporter.js
+++ b/webroot/js/dataExporter.js
@@ -13,15 +13,22 @@ function exportCsvQueryData() {
 					var groupBy = queryResult.group_by;
 					if (groupBy) {
 						$.each(groupBy, function (index, group) {
-							groupByMessage += "group_by:" + group.name + ',';
-
-							var first = true;
-							$.each(group.group, function (key, value) {
-								if (!first)
-									groupByMessage += ", ";
-								groupByMessage += key + '=' + value;
-								first = false;
-							});
+							if (group.group)
+                                                        {
+                                                                if(groupByMessage != "")
+                                                                        groupByMessage += "," + group.name;
+                                                                else
+                                                                        groupByMessage += "group_by:" + group.name;
+                                                                var first = true;
+                                                                groupByMessage += "(";
+                                                                $.each(group.group, function (key, value) {
+                                                                        if (!first)
+                                                                                groupByMessage += ", ";
+                                                                        groupByMessage += key + '=' + value;
+                                                                        first = false;
+                                                                });
+                                                                groupByMessage += ")";
+                                                        }
 						});
 					}
 


### PR DESCRIPTION
Hi! This PR fixes CSV export problem. This object:
{
 "name":"type",
 "type":"number"
}
always exists In queryResult object in groupby field 
I have no idea what is that :) I think it is some service field. But it doesn't have "group" property and export process failes because of this. My PR fixes this problem just by skeeping this object