### PR TITLE
Corrected bug in tag name search for group by when metric was deleted

### DIFF
--- a/webroot/index.html
+++ b/webroot/index.html
@@ -134,7 +134,7 @@
 			// Autocomplete for GroupBy dialog
 			$("#autocompleteTagName").combobox().combobox({source: function (request, response) {
 					var selectedTabIndex = $("#tabs").tabs("option", "active");
-					var metricName = $('#metricContainer' + selectedTabIndex).find(".metricName").combobox("value");
+					var metricName = $('#metricContainer' + tabContainerMap[selectedTabIndex]).find(".metricName").combobox("value");
 					if (metricName){
 						var tags = [];
 						$.each(metricToTags[metricName], function(tag){

--- a/webroot/js/graph.js
+++ b/webroot/js/graph.js
@@ -1,4 +1,5 @@
 var metricToTags = {};
+var tabContainerMap = [];
 
 function displayQuery() {
 	var queryString = $('#query-hidden-text').val();
@@ -255,8 +256,14 @@ function removeMetric(removeButton) {
 	if (metricCount == 0) {
 		return;
 	}
-
+	
 	var count = removeButton.data("metricCount");
+	for (var index = 0; index < tabContainerMap.length; ++index) {
+		if(tabContainerMap[index]===count) {
+			tabContainerMap.splice(index,1);
+			break;
+		}
+	}
 	$('#metricContainer' + count).remove();
 	$('#metricTab' + count).remove();
 	$("#tabs").tabs("refresh");
@@ -392,9 +399,9 @@ function addMetric() {
 	// Tell tabs object to update changes
 	var $tabs = $("#tabs");
 	$tabs.tabs("refresh");
-
 	// Activate newly added tab
 	var lastTab = $(".ui-tabs-nav").children().size() - 1;
+	tabContainerMap[lastTab] = metricCount;
 	$tabs.tabs({active: lastTab});
 }
 


### PR DESCRIPTION
I've noticed a small bug when calling the tag search utility in the group by tag section: if the metric before was deleted, it does not work. This is because the metric name used by the combobox to fetch tags is that of the deleted metric. Indeed it uses the tab index which is different from the metric container index.

Cheers !