### PR TITLE
Update TimeUnit with AL 2.0 header

### DIFF
--- a/src/main/java/org/kairosdb/core/datastore/TimeUnit.java
+++ b/src/main/java/org/kairosdb/core/datastore/TimeUnit.java
@@ -1,15 +1,18 @@
-// KairosDB2
-// Copyright (C) 2013 Proofpoint, Inc.
-//
-// This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU Lesser General Public License as published by
-// the Free Software Foundation, either version 2.1 of the License, or (at your
-// option) any later version.  This program is distributed in the hope that it
-// will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty
-// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser
-// General Public License for more details.  You should have received a copy
-// of the GNU Lesser General Public License along with this program.  If not,
-// see <http://www.gnu.org/licenses/>
+/*
+ * Copyright 2013 Proofpoint Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
 
 package org.kairosdb.core.datastore;
 


### PR DESCRIPTION
Updated the class header with Apache 2.0. KairosDB itself is an Apache 2.0 license while this particular class (org.kairosdb.core.datastore.TimeUnit) still has a header with LGPL in it. Wasn't sure if this was intended, sent a pull request with a change any case. Pls. feel free to let me know otherwise.  

Thanks!