### PR TITLE
Fixed critical bug on time zone deserialization

### DIFF
--- a/src/main/java/org/kairosdb/core/datastore/Sampling.java
+++ b/src/main/java/org/kairosdb/core/datastore/Sampling.java
@@ -21,30 +21,30 @@ import org.joda.time.DateTimeZone;
 
 public class Sampling extends Duration
 {
-	private DateTimeZone m_timeZone;
-
+	private DateTimeZone time_zone;
+	
 	public Sampling()
 	{
 		super();
 	}
-
+	
 	public Sampling(int value, TimeUnit unit)
 	{
 		super(value, unit);
-		this.m_timeZone = DateTimeZone.UTC;
+		this.time_zone = DateTimeZone.UTC;
 	}
-
+	
 	public Sampling(int value, TimeUnit unit, DateTimeZone timeZone)
 	{
 		super(value, unit);
-		this.m_timeZone = timeZone;
+		this.time_zone = timeZone;
 	}
-
+	
 	public DateTimeZone getTimeZone()
 	{
-		return m_timeZone;
+		return time_zone;
 	}
-
+	
 	/**
 	 Computes the duration of the sampling (value * unit) starting at timestamp.
 
@@ -54,7 +54,7 @@ public class Sampling extends Duration
 	public long getSamplingDuration(long timestamp)
 	{
 		long sampling = (long) value;
-		DateTime dt = new DateTime(timestamp, m_timeZone);
+		DateTime dt = new DateTime(timestamp, time_zone);
 		switch (unit)
 		{
 			case YEARS:

--- a/src/test/java/org/kairosdb/core/http/rest/json/GsonParserTest.java
+++ b/src/test/java/org/kairosdb/core/http/rest/json/GsonParserTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import org.joda.time.DateTimeZone;
 import static org.junit.Assert.fail;
 
 public class GsonParserTest
@@ -304,7 +305,15 @@ public class GsonParserTest
 
 		assertBeanValidation(json, "query.metric[0].aggregators[0].sampling.value must be greater than or equal to 1");
 	}
-
+        
+        @Test
+	public void test_aggregator_sampling_timezone_invalid() throws IOException, QueryException
+	{
+		String json = Resources.toString(Resources.getResource("invalid-query-metric-aggregators-sampling-timezone.json"), Charsets.UTF_8);
+		
+		assertBeanValidation(json, "query.metric[0].aggregators[0].bogus is not a valid time zone, must be one of " + DateTimeZone.getAvailableIDs());
+	}
+	
 	@Test
 	public void test_aggregator_sum_noSampling_valid() throws IOException, QueryException
 	{

--- a/src/test/resources/invalid-query-metric-aggregators-sampling-timezone.json
+++ b/src/test/resources/invalid-query-metric-aggregators-sampling-timezone.json
@@ -1,0 +1,24 @@
+{
+	"start_absolute": 784041330,
+	"end_absolute": 788879730,
+	"metrics": [
+		{
+			"name": "abc.123",
+			"tags": {
+				"host": "foo",
+				"type": "bar"
+			},
+			"aggregators": [
+				{
+					"name" : "sum",
+					"sampling": {
+						"value": 1,
+						"unit": "minutes",
+                                                "time_zone": "bogus"
+                                                
+					}
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Timezone was simply linked to json parameter m_timeZone instead of time_zone as expected