### PR TITLE
Fixes too many open files error #175 when grouping

### DIFF
--- a/src/main/java/org/kairosdb/core/groupby/Group.java
+++ b/src/main/java/org/kairosdb/core/groupby/Group.java
@@ -52,6 +52,7 @@ public class Group
 	private String name;
 	private HashMultimap<String, String> tags = HashMultimap.create();
 	private int m_dataPointCount; //Number of datapoints written to file
+	private DataPointGroup m_dataPointGroup;
 
 	private final KairosDataPointFactory dataPointFactory;
 	private final Map<String, Integer> storageTypeIdMap;
@@ -68,6 +69,7 @@ public class Group
 		storageTypeIdMap = new HashMap<String, Integer>();
 		dataPointFactories = new ArrayList<DataPointFactory>();
 
+		m_dataPointGroup = dataPointGroup;
 		m_groupCacheFile = file;
 
 		m_dataOutputStream = new DataOutputStream(new BufferedOutputStream(
@@ -185,6 +187,8 @@ public class Group
 		@Override
 		public void close()
 		{
+			m_dataPointGroup.close();
+
 			try
 			{
 				m_dataInputStream.close();


### PR DESCRIPTION
This is a fix to the too many files open bug #175 #132 and others. When grouping the underlying DataPointGroup isn't being closed like it is in other scenarios.