### PR TITLE
Bug fix for the charts not getting displayed

### DIFF
--- a/webroot/js/graph.js
+++ b/webroot/js/graph.js
@@ -765,7 +765,7 @@ function showChart(subTitle, queries, metricData) {
 				});
 			}
 
-			if (groupType != 'number')
+			if (groupType && groupType != 'number')
 				return;
 
 			var result = {};


### PR DESCRIPTION
Despite /api/v1/datapoints/query responding with the correct results, the chart was not getting displayed since the results variable was not getting populated due to the return statement. 

-	if (groupType != 'number')		
 				return;

After checking for groupType only when it is set, the chart is correctly populated.

+	if (groupType && groupType != 'number')
 				return;