### PR TITLE
Fix newline characters in telnet documentation

### DIFF
--- a/src/docs/PushingData.rst
+++ b/src/docs/PushingData.rst
@@ -15,7 +15,7 @@ Submitting data via telnet
 The format of the data is 
 ::
 
-	put <metric name> <time stamp> <value> <tag> <tag>... /n
+	put <metric name> <time stamp> <value> <tag> <tag>... \n
 
 **Metric name** must be one word and is limited to alpha numerics with "-_.".
 

--- a/src/docs/telnetapi/Put.rst
+++ b/src/docs/telnetapi/Put.rst
@@ -7,7 +7,7 @@ You can submit data either with the telnet protocol on port 4242. The port can b
 The format of the data is
 ::
 
-	put <metric name> <time stamp> <value> <tag> <tag>... /n
+	put <metric name> <time stamp> <value> <tag> <tag>... \n
 
 
 **Metric name** must be one word and is limited to alpha numerics with "-_.".

--- a/src/docs/telnetapi/Putm.rst
+++ b/src/docs/telnetapi/Putm.rst
@@ -9,7 +9,7 @@ You can submit data either with the telnet protocol on port 4242. The port can b
 The format of the data is
 ::
 
-	putm <metric name> <time stamp> <value> <tag> <tag>... /n
+	putm <metric name> <time stamp> <value> <tag> <tag>... \n
 
 
 **Metric name** must be one word and is limited to utf8 characters.

--- a/src/docs/telnetapi/Version.rst
+++ b/src/docs/telnetapi/Version.rst
@@ -6,7 +6,7 @@ The version command returns the product name (KairosDB) and its version.
 
 ::
 
- version /n
+ version \n
 
 The output looks like this
 


### PR DESCRIPTION
This fixes the newline characters to the proper \n ones.