### PR TITLE
Fix a typo in kairosdb-service.sh

### DIFF
--- a/src/scripts/kairosdb-service.sh
+++ b/src/scripts/kairosdb-service.sh
@@ -15,13 +15,14 @@ export KAIROS_PID_FILE="/var/run/kairosdb.pid"
 if [ -f /etc/init.d/functions ]
     . /etc/init.d/functions
 
+# Start the service KairosDB
 start() {
         printf "%-50s" "Starting KairosDB server: "
         $KAIROS_SCRIPT_PATH start
         echo
 }
 
-# Restart the service KairosDB
+# Stop the service KairosDB
 stop() {
         printf "%-50s" "Stopping KairosDB server: "
         $KAIROS_SCRIPT_PATH stop


### PR DESCRIPTION
The comment for the stop function is `Restart`, change it to `Stop` and add comment for start as well. 