### PR TITLE
Fix link to installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Documentation is found [here](http://kairosdb.github.io/website/).
 
 Download the latest [KairosDB release](https://github.com/kairosdb/kairosdb/releases).
 
-Installation instructions are found [here](http://kairosdb.github.io/website/docs/build/html/GettingStarted.html#install)
+Installation instructions are found [here](http://kairosdb.github.io/docs/build/html/GettingStarted.html#install)
 
 ## Getting Involved
 


### PR DESCRIPTION
Link to installation instruction in README.md was broken.
I'm not sure, if this is a problem with the link itself, or with routing configuration on the website. If it's the latter the website should be fixed instead and this pull request should be declined.