### PR TITLE
Fix data-point TTL overwriting

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraDatastore.java
@@ -299,7 +299,7 @@ public class CassandraDatastore implements Datastore
 			DataPointsRowKey rowKey = null;
 			//time the data is written.
 			long writeTime = System.currentTimeMillis();
-			if (ttl != 0)
+			if (0 == ttl)
 				ttl = m_cassandraConfiguration.getDatapointTtl();
 
 			int rowKeyTtl = 0;


### PR DESCRIPTION
I found a little issue in the Cassandra per-data point TTL that prevented any data point TTL's from being written to Cassandra, and this fixed it for me.