### PR TITLE
Buffer writer encoding fix for cached files

### DIFF
--- a/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
+++ b/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
@@ -400,7 +400,7 @@ public class MetricsResource implements KairosMetricReporter
 		try
 		{
 			File respFile = File.createTempFile("kairos", ".json", new File(datastore.getCacheDir()));
-			BufferedWriter writer = new BufferedWriter(new FileWriter(respFile));
+			BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(respFile), "UTF-8"));
 
 			JsonResponse jsonResponse = new JsonResponse(writer);
 


### PR DESCRIPTION
Hi,

We were trying to send and read data points which string values contan Russian symbols.
As turns out, Kairosdb returns data in incorrect encoding and we cannot handle it properly.

We've found out that the reason of it is the encoding of the cache files which are used to store responses received from Cassandra.

Have a look at our fix. Please note that we are not Java developers.
If our fix is correct, please add it to your next release.

Thanks in advance!