### PR TITLE
Add logs compression and compression when file reaches 100mb.

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -17,10 +17,19 @@
 		<file>log/kairosdb.log</file>
 		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
 			<!-- daily rollover -->
-			<fileNamePattern>log/kairosdb.%d{yyyy-MM-dd}.log</fileNamePattern>
+			<fileNamePattern>log/kairosdb.%d.log.gz</fileNamePattern>
 
 			<!-- keep 30 days' worth of history -->
 			<maxHistory>30</maxHistory>
+
+			<!-- or whenever the file size reaches 100MB -->
+			<timeBasedFileNamingAndTriggeringPolicy
+				class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+				<maxFileSize>100MB</maxFileSize>
+			</timeBasedFileNamingAndTriggeringPolicy>
+
+			<!-- Whenever startup, will run the rollover -->
+			<cleanHistoryOnStart>true</cleanHistoryOnStart>
 		</rollingPolicy>
 		<encoder>
 			<pattern>%d{MM-dd|HH:mm:ss.SSS} [%thread] %-5level [%file:%line] - %msg%n</pattern>


### PR DESCRIPTION
Solves the problem from #258 . This pull request implements the following features:

- Every past log will be compressed into a .gz file.
- Whenever a log reaches 100MB of storage, the log for the current day will be compressed and a new one will be created to keep logging things for this day.
- Whenever start the appender will perform a check to clean history (if needed). 

I've built the source code and tested in my localhost - everything is fine, the compression is working as expected.