### PR TITLE
Allow overwriting any existing property via environment variable

### DIFF
--- a/src/main/java/org/kairosdb/core/Main.java
+++ b/src/main/java/org/kairosdb/core/Main.java
@@ -116,6 +116,23 @@ public class Main
 		return jars.toArray(new URL[0]);
 	}
 
+	protected static String toEnvVarName(String propName) {
+		return propName.toUpperCase().replace('.', '_');
+	}
+
+	/*
+	 * allow overwriting any existing property via correctly named environment variable
+	 * e.g. kairosdb.datastore.cassandra.host_list via KAIROSDB_DATASTORE_CASSANDRA_HOST_LIST
+	 */
+	protected void applyEnvironmentVariables(Properties props) {
+		Map<String, String> env = System.getenv();
+		for (String propName : props.stringPropertyNames()) {
+			String envVarName = toEnvVarName(propName);
+			if (env.containsKey(envVarName)) {
+				props.setProperty(propName, env.get(envVarName));
+			}
+		}
+	}
 
 	public Main(File propertiesFile) throws IOException
 	{
@@ -132,6 +149,8 @@ public class Main
 
 			loadPlugins(props, propertiesFile);
 		}
+
+		applyEnvironmentVariables(props);
 
 		List<Module> moduleList = new ArrayList<Module>();
 		moduleList.add(new CoreModule(props));


### PR DESCRIPTION
This is a small change with huge impact for everyone using KairosDB in a container environment following the "12 factor" app principles (http://12factor.net/).

Allow overwriting any existing property via correctly named environment variable, e.g. `kairosdb.datastore.cassandra.host_list` can be overwritten by setting `KAIROSDB_DATASTORE_CASSANDRA_HOST_LIST`.

* we build a Docker image in https://github.com/zalando/kairosdb
* you can try it out with `docker run -it registry.opensource.zalan.do/stups/kairosdb:cd13`
* example env vars: https://github.com/zalando-zmon/zmon-demo/blob/master/bootstrap/bootstrap.sh#L98