### PR TITLE
Web UI refusing to plot non-numeric data types when aggregated as numerics

### DIFF
--- a/webroot/js/graph.js
+++ b/webroot/js/graph.js
@@ -767,8 +767,6 @@ function showChart(subTitle, queries, metricData) {
 				});
 			}
 
-			if (groupType && groupType != 'number')
-				return;
 
 			var result = {};
 			result.name = queryResult.name + groupByMessage;


### PR DESCRIPTION
Q&D fix for Web UI refusing to plot non-numeric data types to be plotted although they are aggregated to number values.
It doesn;t solve the root cause. but it helps.
cf. issue #298 for description of the root problem.