### PR TITLE
Added rollover filter for rate aggregator and added new Non-Negative Rate Aggregator

### DIFF
--- a/src/main/java/org/kairosdb/core/CoreModule.java
+++ b/src/main/java/org/kairosdb/core/CoreModule.java
@@ -86,6 +86,7 @@ public class CoreModule extends AbstractModule
 		bind(AvgAggregator.class);
 		bind(StdAggregator.class);
 		bind(RateAggregator.class);
+		bind(NonNegativeRateAggregator.class);
 		bind(SamplerAggregator.class);
 		bind(LeastSquaresAggregator.class);
 		bind(PercentileAggregator.class);
@@ -99,7 +100,6 @@ public class CoreModule extends AbstractModule
 		bind(SaveAsAggregator.class);
 		bind(TrimAggregator.class);
 		bind(SmaAggregator.class);
-
 
 		bind(ValueGroupBy.class);
 		bind(TimeGroupBy.class);

--- a/src/main/java/org/kairosdb/core/aggregator/NonNegativeRateAggregator.java
+++ b/src/main/java/org/kairosdb/core/aggregator/NonNegativeRateAggregator.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2013 Proofpoint Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.kairosdb.core.aggregator;
+
+import com.google.inject.Inject;
+import org.joda.time.DateTimeZone;
+import org.kairosdb.core.DataPoint;
+import org.kairosdb.core.aggregator.annotation.AggregatorName;
+import org.kairosdb.core.datapoints.DoubleDataPointFactory;
+import org.kairosdb.core.datastore.DataPointGroup;
+import org.kairosdb.core.datastore.Sampling;
+import org.kairosdb.core.datastore.TimeUnit;
+import org.kairosdb.util.Util;
+
+@AggregatorName(name = "non_negative_rate", description = "Computes the rate of change for the data points and returns only positive values.")
+public class NonNegativeRateAggregator implements Aggregator, TimezoneAware
+{
+	private Sampling m_sampling;
+	private DoubleDataPointFactory m_dataPointFactory;
+	private DateTimeZone m_timeZone;
+
+	@Inject
+	public NonNegativeRateAggregator(DoubleDataPointFactory dataPointFactory)
+	{
+		m_sampling = new Sampling(1, TimeUnit.MILLISECONDS);
+		m_dataPointFactory = dataPointFactory;
+	}
+
+	@Override
+	public boolean canAggregate(String groupType)
+	{
+		return DataPoint.GROUP_NUMBER.equals(groupType);
+	}
+
+	public DataPointGroup aggregate(DataPointGroup dataPointGroup)
+	{
+		return (new NonNegativeRateDataPointAggregator(dataPointGroup));
+	}
+
+	public void setSampling(Sampling sampling)
+	{
+		m_sampling = sampling;
+	}
+
+	public void setUnit(TimeUnit timeUnit)
+	{
+		m_sampling = new Sampling(1, timeUnit);
+	}
+
+	@Override
+	public void setTimeZone(DateTimeZone timeZone)
+	{
+		m_timeZone = timeZone;
+	}
+
+
+	private class NonNegativeRateDataPointAggregator extends AggregatedDataPointGroupWrapper
+	{
+		public NonNegativeRateDataPointAggregator(DataPointGroup innerDataPointGroup)
+		{
+			super(innerDataPointGroup);
+		}
+
+		@Override
+		public boolean hasNext()
+		{
+			//Ensure we have two data points to mess with
+			return currentDataPoint != null && hasNextInternal();
+		}
+
+		@Override
+		public DataPoint next()
+		{
+			final double x0 = currentDataPoint.getDoubleValue();
+			final long y0 = currentDataPoint.getTimestamp();
+
+			//This defaults the rate to 0 if no more data points exists
+			double x1 = x0;
+			long y1 = y0+1;
+
+			if (hasNextInternal())
+			{
+				currentDataPoint = nextInternal();
+
+				x1 = currentDataPoint.getDoubleValue();
+				y1 = currentDataPoint.getTimestamp();
+
+				if (y1 == y0)
+				{
+					throw new IllegalStateException(
+							"The rate aggregator cannot compute rate for data points with the same time stamp.  "+
+							"You must precede rate with another aggregator.");
+				}
+			}
+
+			double rate = (x1 - x0)/(y1 - y0) * Util.getSamplingDuration(y0, m_sampling, m_timeZone);
+			if (rate < 0.0)
+				rate = 0.0;
+
+			return (m_dataPointFactory.createDataPoint(y1, rate));
+		}
+	}
+}

--- a/src/test/java/org/kairosdb/core/aggregator/NonNegativeRateAggregatorTest.java
+++ b/src/test/java/org/kairosdb/core/aggregator/NonNegativeRateAggregatorTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2013 Proofpoint Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.kairosdb.core.aggregator;
+
+import org.junit.Test;
+import org.kairosdb.core.DataPoint;
+import org.kairosdb.core.datapoints.DoubleDataPointFactoryImpl;
+import org.kairosdb.core.datapoints.LongDataPoint;
+import org.kairosdb.core.datastore.DataPointGroup;
+import org.kairosdb.testing.ListDataPointGroup;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class NonNegativeRateAggregatorTest
+{
+	@Test(expected = NullPointerException.class)
+	public void test_nullSet_invalid()
+	{
+		new NonNegativeRateAggregator(new DoubleDataPointFactoryImpl()).aggregate(null);
+	}
+
+	@Test
+	public void test_steadyRate()
+	{
+		ListDataPointGroup group = new ListDataPointGroup("rate");
+		group.addDataPoint(new LongDataPoint(1, 10));
+		group.addDataPoint(new LongDataPoint(2, 20));
+		group.addDataPoint(new LongDataPoint(3, 30));
+		group.addDataPoint(new LongDataPoint(4, 40));
+
+		NonNegativeRateAggregator rateAggregator = new NonNegativeRateAggregator(new DoubleDataPointFactoryImpl());
+		DataPointGroup results = rateAggregator.aggregate(group);
+
+		DataPoint dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(2L));
+		assertThat(dp.getDoubleValue(), equalTo(10.0));
+
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(3L));
+		assertThat(dp.getDoubleValue(), equalTo(10.0));
+
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(4L));
+		assertThat(dp.getDoubleValue(), equalTo(10.0));
+	}
+
+	@Test
+	public void test_steadyRateOver2Sec()
+	{
+		ListDataPointGroup group = new ListDataPointGroup("rate");
+		group.addDataPoint(new LongDataPoint(1, 10));
+		group.addDataPoint(new LongDataPoint(3, 20));
+		group.addDataPoint(new LongDataPoint(5, 30));
+		group.addDataPoint(new LongDataPoint(7, 40));
+
+		NonNegativeRateAggregator rateAggregator = new NonNegativeRateAggregator(new DoubleDataPointFactoryImpl());
+		DataPointGroup results = rateAggregator.aggregate(group);
+
+		DataPoint dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(3L));
+		assertThat(dp.getDoubleValue(), equalTo(5.0));
+
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(5L));
+		assertThat(dp.getDoubleValue(), equalTo(5.0));
+
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(7L));
+		assertThat(dp.getDoubleValue(), equalTo(5.0));
+	}
+
+	@Test
+	public void test_changingRate()
+	{
+		ListDataPointGroup group = new ListDataPointGroup("rate");
+		group.addDataPoint(new LongDataPoint(1, 10));
+		group.addDataPoint(new LongDataPoint(2, 10));
+		group.addDataPoint(new LongDataPoint(3, 5));
+		group.addDataPoint(new LongDataPoint(4, 20));
+
+		NonNegativeRateAggregator rateAggregator = new NonNegativeRateAggregator(new DoubleDataPointFactoryImpl());
+		DataPointGroup results = rateAggregator.aggregate(group);
+
+		DataPoint dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(2L));
+		assertThat(dp.getDoubleValue(), equalTo(0.0));
+
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(3L));
+		assertThat(dp.getDoubleValue(), equalTo(0.0));
+
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(4L));
+		assertThat(dp.getDoubleValue(), equalTo(15.0));
+	}
+
+	@Test
+	public void test_negativeRates()
+	{
+		ListDataPointGroup group = new ListDataPointGroup("rate");
+		group.addDataPoint(new LongDataPoint(1, 5));
+		group.addDataPoint(new LongDataPoint(2, 10));
+		group.addDataPoint(new LongDataPoint(3, 12));
+		group.addDataPoint(new LongDataPoint(4, 21));
+		group.addDataPoint(new LongDataPoint(5, 2));
+		group.addDataPoint(new LongDataPoint(6, 8));
+
+		NonNegativeRateAggregator rateAggregator = new NonNegativeRateAggregator(new DoubleDataPointFactoryImpl());
+		DataPointGroup results = rateAggregator.aggregate(group);
+
+		DataPoint dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(2L));
+		assertThat(dp.getDoubleValue(), equalTo(5.0));
+
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(3L));
+		assertThat(dp.getDoubleValue(), equalTo(2.0));
+
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(4L));
+		assertThat(dp.getDoubleValue(), equalTo(9.0));
+
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(5L));
+		assertThat(dp.getDoubleValue(), equalTo(0.0));
+
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(6L));
+		assertThat(dp.getDoubleValue(), equalTo(6.0));
+	}
+
+	@Test(expected = IllegalStateException.class)
+	public void test_dataPointsAtSameTime()
+	{
+		ListDataPointGroup group = new ListDataPointGroup("rate");
+		group.addDataPoint(new LongDataPoint(1, 10));
+		group.addDataPoint(new LongDataPoint(1, 15));
+		group.addDataPoint(new LongDataPoint(2, 5));
+		group.addDataPoint(new LongDataPoint(2, 20));
+		group.addDataPoint(new LongDataPoint(3, 30));
+
+
+		NonNegativeRateAggregator rateAggregator = new NonNegativeRateAggregator(new DoubleDataPointFactoryImpl());
+		DataPointGroup results = rateAggregator.aggregate(group);
+
+		DataPoint dp = results.next();
+	}
+
+}

--- a/src/test/java/org/kairosdb/core/aggregator/RateAggregatorTest.java
+++ b/src/test/java/org/kairosdb/core/aggregator/RateAggregatorTest.java
@@ -109,6 +109,41 @@ public class RateAggregatorTest
 		assertThat(dp.getDoubleValue(), equalTo(15.0));
 	}
 
+	@Test
+	public void test_counterRolloverRate()
+	{
+		ListDataPointGroup group = new ListDataPointGroup("rate");
+		group.addDataPoint(new LongDataPoint(1, 5));
+		group.addDataPoint(new LongDataPoint(2, 10));
+		group.addDataPoint(new LongDataPoint(3, 12));
+		group.addDataPoint(new LongDataPoint(4, 21));
+		group.addDataPoint(new LongDataPoint(5, 0));
+		group.addDataPoint(new LongDataPoint(6, 8));
+
+		RateAggregator rateAggregator = new RateAggregator(new DoubleDataPointFactoryImpl());
+		rateAggregator.setRolloverFilter(true);
+		DataPointGroup results = rateAggregator.aggregate(group);
+
+		DataPoint dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(2L));
+		assertThat(dp.getDoubleValue(), equalTo(5.0));
+
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(3L));
+		assertThat(dp.getDoubleValue(), equalTo(2.0));
+
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(4L));
+		assertThat(dp.getDoubleValue(), equalTo(9.0));
+
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(5L));
+		assertThat(dp.getDoubleValue(), equalTo(9.0));
+
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(6L));
+		assertThat(dp.getDoubleValue(), equalTo(8.0));
+	}
 
 	@Test(expected = IllegalStateException.class)
 	public void test_dataPointsAtSameTime()

--- a/webroot/index.html
+++ b/webroot/index.html
@@ -469,6 +469,7 @@
 				<option value="min">MIN</option>
 				<option value="percentile">PERCENTILE</option>
 				<option value="rate">RATE</option>
+				<option value="non_negative_rate">NON-NEGATIVE RATE</option>
 				<option value="sampler">SAMPLER</option>
 				<option value="save_as">SAVE AS</option>
 				<option value="scale">SCALE</option>

--- a/webroot/index.html
+++ b/webroot/index.html
@@ -86,6 +86,8 @@
 			$(".aggregatorTrim").hide();
 			$(".aggregatorSaveAs").hide();
 			$(".aggregatorRate").hide();
+			$(".rateRolloverFilter").hide();
+			$(".rateRolloverFilterLabel").hide();
 			$("#tabs").tabs({'active': 0});
 
 			$startTime.bind("change paste keyup", function(){
@@ -537,6 +539,8 @@
 				<option value="seconds">Seconds</option>
 				<option value="milliseconds" selected="selected">Milliseconds</option>
 			</select>
+			<input class="ui-widget rateRolloverFilter" id="rateRolloverFilter" style="margin-left: 10px;" type="checkbox">
+			<label class="ui-widget rateRolloverFilterLabel" id="rateRolloverFilterLabel">Rollover Filter</label><br>
 		</div>
 
 		<div style="float: left" class="aggregatorTrim">

--- a/webroot/js/graph.js
+++ b/webroot/js/graph.js
@@ -119,7 +119,8 @@ function buildKairosDBQuery() {
 			}
 			else if (name == 'rate') {
 				unit = $(aggregator).find(".rateUnit").val();
-				metric.addRate(unit, time_zone);
+				var rollover_filter = $(aggregator).find(".rateRolloverFilter").is(':checked');
+				metric.addRate(unit, time_zone, rollover_filter);
 			}
 			else if (name == 'sampler') {
 				unit = $(aggregator).find(".rateUnit").val();
@@ -611,12 +612,18 @@ function addAggregator(container) {
 		$aggregatorContainer.find(".aggregatorSaveAs").hide();
 		$aggregatorContainer.find(".aggregatorRate").hide();
 		$aggregatorContainer.find(".aggregatorAlignStartTime").hide();
+		$aggregatorContainer.find(".rateRolloverFilter").hide();
+		$aggregatorContainer.find(".rateRolloverFilterLabel").hide();
 
 		if (name == "rate" || name == "sampler") {
 			$aggregatorContainer.find(".aggregatorRate").show();
 			$aggregatorContainer.find(".aggregatorSamplingUnit").show();
 			// clear values
 			$aggregatorContainer.find(".aggregatorSamplingValue").val("");
+			if (name == "rate") {
+				$aggregatorContainer.find(".rateRolloverFilter").show();
+				$aggregatorContainer.find(".rateRolloverFilterLabel").show();
+			}
 		}
 		else if (name == "percentile") {
 			$aggregatorContainer.find(".aggregatorPercentile").show().css('display', 'table-cell');

--- a/webroot/js/graph.js
+++ b/webroot/js/graph.js
@@ -122,6 +122,10 @@ function buildKairosDBQuery() {
 				var rollover_filter = $(aggregator).find(".rateRolloverFilter").is(':checked');
 				metric.addRate(unit, time_zone, rollover_filter);
 			}
+			else if (name == 'non_negative_rate') {
+				unit = $(aggregator).find(".rateUnit").val();
+				metric.addNonNegativeRate(unit, time_zone);
+			}
 			else if (name == 'sampler') {
 				unit = $(aggregator).find(".rateUnit").val();
 				metric.addSampler(unit);
@@ -615,7 +619,7 @@ function addAggregator(container) {
 		$aggregatorContainer.find(".rateRolloverFilter").hide();
 		$aggregatorContainer.find(".rateRolloverFilterLabel").hide();
 
-		if (name == "rate" || name == "sampler") {
+		if (name == "rate" || name == "non_negative_rate" || name == "sampler") {
 			$aggregatorContainer.find(".aggregatorRate").show();
 			$aggregatorContainer.find(".aggregatorSamplingUnit").show();
 			// clear values

--- a/webroot/js/kairosdb.js
+++ b/webroot/js/kairosdb.js
@@ -84,6 +84,23 @@ kairosdb.Metric = function (name) {
 		return this;
 	};
 
+	this.addNonNegativeRate = function (unit, time_zone) {
+		if (!this.aggregators)
+			this.aggregators = [];
+
+		var non_neg_rate = {};
+		non_neg_rate.name = "non_negative_rate";
+		if (unit) {
+			non_neg_rate.sampling = {};
+			non_neg_rate.sampling.unit = unit;
+			non_neg_rate.sampling.value = 1;
+			non_neg_rate.sampling.time_zone = time_zone;
+		}
+
+		this.aggregators.push(non_neg_rate);
+		return this;
+	};
+
 	this.addSampler = function (unit) {
 		if (!this.aggregators)
 			this.aggregators = [];

--- a/webroot/js/kairosdb.js
+++ b/webroot/js/kairosdb.js
@@ -66,7 +66,7 @@ kairosdb.Metric = function (name) {
 		return this;
 	};
 
-	this.addRate = function (unit, time_zone) {
+	this.addRate = function (unit, time_zone, rollover_filter) {
 		if (!this.aggregators)
 			this.aggregators = [];
 
@@ -78,6 +78,7 @@ kairosdb.Metric = function (name) {
 			rate.sampling.value = 1;
             		rate.sampling.time_zone = time_zone;
 		}
+		rate.rollover_filter = rollover_filter
 
 		this.aggregators.push(rate);
 		return this;


### PR DESCRIPTION
I added support for a "rollover" filter when using the rate aggregator. It defaults to not being used but can be set to True during a query which causes the rate aggregator to detect when an underlying counter metric would rollover. The rollover filter will use the previous rate to smooth out the line. I also added a non-negative rate aggregator which will only return the non-negative rate (as the name implies). All additions include test cases and support in the KairosDB GUI.