### PR TITLE
Cleanup compilation warnings.

### DIFF
--- a/src/main/java/org/kairosdb/core/datastore/GuiceQueryPluginFactory.java
+++ b/src/main/java/org/kairosdb/core/datastore/GuiceQueryPluginFactory.java
@@ -4,8 +4,6 @@ import com.google.inject.Binding;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Key;
-import org.kairosdb.core.aggregator.Aggregator;
-import org.kairosdb.core.aggregator.annotation.AggregatorName;
 import org.kairosdb.core.annotation.PluginName;
 
 import java.util.HashMap;

--- a/src/main/java/org/kairosdb/core/telnet/GuiceCommandProvider.java
+++ b/src/main/java/org/kairosdb/core/telnet/GuiceCommandProvider.java
@@ -20,8 +20,6 @@ import com.google.inject.Binding;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Key;
-import com.google.inject.name.Names;
-import org.kairosdb.core.reporting.KairosMetricReporter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -37,7 +35,7 @@ public class GuiceCommandProvider implements CommandProvider
 
 		for (Key<?> key : bindings.keySet())
 		{
-			Class bindingClass = key.getTypeLiteral().getRawType();
+			Class<?> bindingClass = key.getTypeLiteral().getRawType();
 			if (TelnetCommand.class.isAssignableFrom(bindingClass))
 			{
 				TelnetCommand command = (TelnetCommand)injector.getInstance(bindingClass);

--- a/src/test/java/org/kairosdb/core/aggregator/SaveAsAggregatorTest.java
+++ b/src/test/java/org/kairosdb/core/aggregator/SaveAsAggregatorTest.java
@@ -13,8 +13,6 @@ import org.kairosdb.core.groupby.TagGroupBy;
 import org.kairosdb.testing.ListDataPointGroup;
 
 import java.util.Collections;
-import java.util.Map;
-import java.util.TreeMap;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;

--- a/src/test/java/org/kairosdb/core/datapoints/DataPointTestCommon.java
+++ b/src/test/java/org/kairosdb/core/datapoints/DataPointTestCommon.java
@@ -4,11 +4,10 @@ import org.junit.Test;
 import org.kairosdb.core.DataPoint;
 
 import java.io.*;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  Created with IntelliJ IDEA.
@@ -48,6 +47,6 @@ public class DataPointTestCommon
 			testSum += dp.getDoubleValue();
 		}
 
-		assertEquals(sum, testSum);
+		assertEquals(sum, testSum, 0.0001);
 	}
 }

--- a/src/test/java/org/kairosdb/core/datastore/CachedSearchResultTest.java
+++ b/src/test/java/org/kairosdb/core/datastore/CachedSearchResultTest.java
@@ -45,7 +45,7 @@ public class CachedSearchResultTest
 
 		long now = System.currentTimeMillis();
 
-		Map<String, String> tags = new HashMap();
+		Map<String, String> tags = new HashMap<String, String>();
 		tags.put("host", "A");
 		tags.put("client", "foo");
 		csResult.startDataPointSet(LegacyDataPointFactory.DATASTORE_TYPE, tags);
@@ -56,7 +56,7 @@ public class CachedSearchResultTest
 		csResult.addDataPoint(new LegacyDoubleDataPoint(now+3, 43.1));
 
 
-		tags = new HashMap();
+		tags = new HashMap<String, String>();
 		tags.put("host", "B");
 		tags.put("client", "foo");
 		csResult.startDataPointSet(LegacyDataPointFactory.DATASTORE_TYPE, tags);
@@ -66,7 +66,7 @@ public class CachedSearchResultTest
 		csResult.addDataPoint(new LegacyLongDataPoint(now+2, 2));
 		csResult.addDataPoint(new LegacyDoubleDataPoint(now+3, 2.1));
 
-		tags = new HashMap();
+		tags = new HashMap<String, String>();
 		tags.put("host", "A");
 		tags.put("client", "bar");
 		csResult.startDataPointSet(LegacyDataPointFactory.DATASTORE_TYPE, tags);

--- a/src/test/java/org/kairosdb/core/groupby/GroupTest.java
+++ b/src/test/java/org/kairosdb/core/groupby/GroupTest.java
@@ -31,7 +31,7 @@ public class GroupTest
 		groupIds.add(2);
 		groupIds.add(3);
 
-		Group group = Group.createGroup(dataPointGroup, groupIds, Collections.EMPTY_LIST, kairosDataPointFactory);
+		Group group = Group.createGroup(dataPointGroup, groupIds, Collections.<GroupByResult>emptyList(), kairosDataPointFactory);
 
 		group.addDataPoint(new LongDataPoint(1, 1));
 		group.addDataPoint(new LongDataPoint(2, 2));

--- a/src/test/java/org/kairosdb/core/http/rest/MetricsResourceTest.java
+++ b/src/test/java/org/kairosdb/core/http/rest/MetricsResourceTest.java
@@ -45,9 +45,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 
-import static junit.framework.Assert.assertEquals;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class MetricsResourceTest

--- a/src/test/java/org/kairosdb/core/http/rest/json/DataPointsParserTest.java
+++ b/src/test/java/org/kairosdb/core/http/rest/json/DataPointsParserTest.java
@@ -748,7 +748,7 @@ public class DataPointsParserTest
 			if ((lastDataPointSet == null) || (!lastDataPointSet.getName().equals(metricName)) ||
 					(!lastDataPointSet.getTags().equals(tags)))
 			{
-				lastDataPointSet = new DataPointSet(metricName, tags, Collections.EMPTY_LIST);
+				lastDataPointSet = new DataPointSet(metricName, tags, Collections.<DataPoint>emptyList());
 				dataPointSetList.add(lastDataPointSet);
 			}
 

--- a/src/test/java/org/kairosdb/core/telnet/PutCommandTest.java
+++ b/src/test/java/org/kairosdb/core/telnet/PutCommandTest.java
@@ -356,7 +356,7 @@ public class PutCommandTest
 				DataPoint dataPoint, int ttl) throws DatastoreException
 		{
 			if (set == null)
-				set = new DataPointSet(metricName, tags, Collections.EMPTY_LIST);
+				set = new DataPointSet(metricName, tags, Collections.<DataPoint>emptyList());
 
 			set.addDataPoint(dataPoint);
 		}

--- a/src/test/java/org/kairosdb/datastore/DatastoreMetricQueryImpl.java
+++ b/src/test/java/org/kairosdb/datastore/DatastoreMetricQueryImpl.java
@@ -83,7 +83,7 @@ public class DatastoreMetricQueryImpl implements DatastoreMetricQuery
 	@Override
 	public List<QueryPlugin> getPlugins()
 	{
-		return Collections.EMPTY_LIST;
+		return Collections.emptyList();
 	}
 
 }

--- a/src/test/java/org/kairosdb/datastore/DatastoreTestHelper.java
+++ b/src/test/java/org/kairosdb/datastore/DatastoreTestHelper.java
@@ -20,11 +20,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.TreeMultimap;
-import junit.framework.TestCase;
-import org.hamcrest.CoreMatchers;
 import org.junit.Test;
-import org.kairosdb.core.DataPoint;
-import org.kairosdb.core.DataPointSet;
 import org.kairosdb.core.datapoints.LongDataPoint;
 import org.kairosdb.core.datastore.DataPointGroup;
 import org.kairosdb.core.datastore.DatastoreQuery;
@@ -35,13 +31,12 @@ import org.kairosdb.core.groupby.TagGroupBy;
 
 import java.util.*;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
 
 public abstract class DatastoreTestHelper
 {

--- a/src/test/java/org/kairosdb/datastore/cassandra/CassandraDatastoreTest.java
+++ b/src/test/java/org/kairosdb/datastore/cassandra/CassandraDatastoreTest.java
@@ -31,13 +31,13 @@ import org.kairosdb.datastore.DatastoreTestHelper;
 import java.io.IOException;
 import java.util.*;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.TestCase.assertEquals;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertEquals;
 
 
 public class CassandraDatastoreTest extends DatastoreTestHelper

--- a/src/test/java/org/kairosdb/datastore/cassandra/DataCacheTest.java
+++ b/src/test/java/org/kairosdb/datastore/cassandra/DataCacheTest.java
@@ -16,14 +16,11 @@
 
 package org.kairosdb.datastore.cassandra;
 
-import junit.framework.Assert;
 import org.junit.Test;
-import org.kairosdb.core.TestDataPointFactory;
 
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 public class DataCacheTest
 {

--- a/src/test/java/org/kairosdb/datastore/cassandra/ValueSerializerTest.java
+++ b/src/test/java/org/kairosdb/datastore/cassandra/ValueSerializerTest.java
@@ -24,7 +24,6 @@ import java.io.DataInput;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 
-import static junit.framework.Assert.assertTrue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.kairosdb.util.Util.packLong;

--- a/src/test/java/org/kairosdb/datastore/h2/H2DatastoreTest.java
+++ b/src/test/java/org/kairosdb/datastore/h2/H2DatastoreTest.java
@@ -33,9 +33,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import static junit.framework.Assert.assertFalse;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertFalse;
 
 public class H2DatastoreTest extends DatastoreTestHelper
 {


### PR DESCRIPTION
There were some warnings when compiling the sources.
These commits removes almost all of them
  - deprecated junit api
  - Collection.EMPTY_LIST replaces with Collection.<>emptyList()
  - other unsafe casts
  - some unused imports removed