### PR TITLE
Fixed logging policy, %i is a required parameter.

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
 		<file>log/kairosdb.log</file>
 		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
 			<!-- daily rollover -->
-			<fileNamePattern>log/kairosdb.%d.log.gz</fileNamePattern>
+			<fileNamePattern>log/kairosdb.%d.%i.log.gz</fileNamePattern>
 
 			<!-- keep 30 days' worth of history -->
 			<maxHistory>30</maxHistory>


### PR DESCRIPTION
Without %i, this error occurs:

18:21:06,350 |-ERROR in ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP@566776ad - Missing integer token, that is %i, in FileNamePattern [log/kairosdb.%d.log.gz]
18:21:06,351 |-WARN in c.q.l.core.rolling.TimeBasedRollingPolicy@796533847 - Subcomponent did not start. TimeBasedRollingPolicy will not start.
18:21:06,351 |-INFO in ch.qos.logback.core.joran.action.NestedComplexPropertyIA - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
18:21:06,352 |-WARN in ch.qos.logback.core.rolling.RollingFileAppender[logfile] - TriggeringPolicy has not started. RollingFileAppender will not start
