### PR TITLE
Use custom static resource server instead of ResourceHandler

### DIFF
--- a/src/main/java/org/kairosdb/core/http/WebServer.java
+++ b/src/main/java/org/kairosdb/core/http/WebServer.java
@@ -184,17 +184,11 @@ public class WebServer implements KairosDBService
 				servletContextHandler.setContextPath("/");
 			}
 
-			servletContextHandler.addFilter(GuiceFilter.class, "/api/*", null);
-			servletContextHandler.addServlet(DefaultServlet.class, "/api/*");
-
-			ResourceHandler resourceHandler = new ResourceHandler();
-			resourceHandler.setDirectoriesListed(true);
-			resourceHandler.setWelcomeFiles(new String[]{"index.html"});
-			resourceHandler.setResourceBase(m_webRoot);
-			resourceHandler.setAliases(true);
+			servletContextHandler.addFilter(GuiceFilter.class, "/*", null);
+			servletContextHandler.addServlet(DefaultServlet.class, "/*");
 
 			HandlerList handlers = new HandlerList();
-			handlers.setHandlers(new Handler[]{servletContextHandler, resourceHandler, new DefaultHandler()});
+			handlers.setHandlers(new Handler[]{servletContextHandler});
 			m_server.setHandler(handlers);
 
 			m_server.start();
@@ -257,6 +251,5 @@ public class WebServer implements KairosDBService
 		csh.setLoginService(l);
 
 		return csh;
-
 	}
 }

--- a/src/main/java/org/kairosdb/core/http/WebServletModule.java
+++ b/src/main/java/org/kairosdb/core/http/WebServletModule.java
@@ -24,6 +24,7 @@ import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
 import org.eclipse.jetty.servlets.GzipFilter;
 import org.kairosdb.core.http.rest.MetadataResource;
 import org.kairosdb.core.http.rest.MetricsResource;
+import org.kairosdb.core.http.rest.StaticResource;
 
 import javax.ws.rs.core.MediaType;
 import java.util.Properties;
@@ -45,6 +46,7 @@ public class WebServletModule extends JerseyServletModule
 
 		//Bind resource classes here
 		bind(MetricsResource.class).in(Scopes.SINGLETON);
+		bind(StaticResource.class).in(Scopes.SINGLETON);
 		bind(MetadataResource.class).in(Scopes.SINGLETON);
 
 		bind(GuiceContainer.class);

--- a/src/main/java/org/kairosdb/core/http/rest/StaticResource.java
+++ b/src/main/java/org/kairosdb/core/http/rest/StaticResource.java
@@ -1,0 +1,87 @@
+package org.kairosdb.core.http.rest;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import org.kairosdb.core.http.WebServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.core.Response;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+@Path("/")
+public class StaticResource
+{
+    private final static String responseTemplate = "<html>" +
+            "   <head>" +
+            "       <meta http-equiv=\"Content-Type\" content=\"text/html;charset=ISO-8859-1\"/>" +
+            "       <title>Error {err_num} {err_msg}</title>" +
+            "   </head>" +
+            "   <body>" +
+            "       <h2>HTTP ERROR: {err_num}</h2><p>Problem accessing /{err_target}. Reason:<pre>    {err_msg}</pre></p>" +
+            "       <hr/><i><small>Powered by KairosDB://</small></i>" +
+            "   </body>" +
+            "</html>";
+    private final static Logger logger = LoggerFactory.getLogger(StaticResource.class);
+    private java.nio.file.Path webroot;
+
+    @Inject
+    public StaticResource(@Named(WebServer.JETTY_WEB_ROOT_PROPERTY) String webroot)
+    {
+        try
+        {
+            this.webroot = Paths.get(new File(".").getCanonicalPath(), webroot);
+
+        } catch (IOException e)
+        {
+            logger.error("Impossible to get webroot or to access static resources.", e);
+        }
+    }
+
+    @GET
+    public Response getRoot() throws IOException
+    {
+        return loadFiles("index.html");
+    }
+
+    @GET
+    @Path("{res : .*}")
+    public Response getResource(@PathParam("res") String resourceName) throws IOException
+    {
+        return loadFiles(resourceName);
+    }
+
+    private Response loadFiles(String pathFile) throws IOException
+    {
+        final File file = new File(String.valueOf(webroot.resolve(pathFile)));
+
+        if (!file.exists())
+            return formatError(Response.Status.NOT_FOUND, pathFile).build();
+        if (!file.isFile() || !file.canRead())
+            return formatError(Response.Status.FORBIDDEN, pathFile).build();
+
+        try (FileInputStream fis = new FileInputStream(file))
+        {
+            final String mediaType = Files.probeContentType(file.toPath());
+            final Response.ResponseBuilder response = Response.ok(Files.readAllBytes(file.toPath()), mediaType);
+
+            return response.build();
+        }
+    }
+
+    private Response.ResponseBuilder formatError(Response.Status status, String target)
+    {
+        final String message = responseTemplate
+                .replaceAll("\\{err_num\\}", String.valueOf(status.getStatusCode()))
+                .replaceAll("\\{err_msg\\}", status.getReasonPhrase())
+                .replaceAll("\\{err_target\\}", target);
+        return Response.status(status).entity(message);
+    }
+}


### PR DESCRIPTION
We've made an authentication mechanism to filter access of KairosDB API and Web UI ([Authentication manager](https://github.com/Kratos-ISE/kairosdb-auth-manager) & [OAuth2 module](https://github.com/Kratos-ISE/kairosdb-oauth2-module)).
But, because `ResourceHandler` create conflict with `GuiceFilter` if we bind them together on `/` (required for filtering access on the WebUI), we've developed a simple static file server.

This is a basic server, without caching file or another features.