### PR TITLE
Added support for JSON and HOCON configuration files

### DIFF
--- a/src/main/java/org/kairosdb/core/GuiceKairosDataPointFactory.java
+++ b/src/main/java/org/kairosdb/core/GuiceKairosDataPointFactory.java
@@ -29,7 +29,6 @@ import java.io.DataInput;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 /**
  Created with IntelliJ IDEA.
@@ -48,7 +47,7 @@ public class GuiceKairosDataPointFactory implements KairosDataPointFactory
 
 
 	@Inject
-	public GuiceKairosDataPointFactory(Injector injector, Properties props)
+	public GuiceKairosDataPointFactory(Injector injector, KairosConfig props)
 	{
 		Map<Key<?>, Binding<?>> bindings = injector.getAllBindings();
 
@@ -70,9 +69,8 @@ public class GuiceKairosDataPointFactory implements KairosDataPointFactory
 			}
 		}
 
-		for (Object prop : props.keySet())
+		for (String key : props.keySet())
 		{
-			String key = (String)prop;
 			if (key.startsWith(DATAPOINTS_FACTORY_PROP_PREFIX))
 			{
 				String className = props.getProperty(key);

--- a/src/main/java/org/kairosdb/core/KairosConfig.java
+++ b/src/main/java/org/kairosdb/core/KairosConfig.java
@@ -1,0 +1,58 @@
+package org.kairosdb.core;
+
+import org.apache.commons.io.FilenameUtils;
+
+import java.io.*;
+import java.util.Map;
+import java.util.Set;
+
+public interface KairosConfig extends Map<String, String>
+{
+    enum ConfigFormat
+    {
+        PROPERTIES("properties"),
+        JSON("json"),
+        HOCON("conf");
+
+        private String extension;
+
+        ConfigFormat(String extension)
+        {
+            this.extension = extension;
+        }
+
+        public String getExtension()
+        {
+            return this.extension;
+        }
+
+        public static ConfigFormat fromFileName(String fileName)
+        {
+            return fromExtension(FilenameUtils.getExtension(fileName));
+        }
+
+        public static ConfigFormat fromExtension(String extension)
+        {
+            for (ConfigFormat format : ConfigFormat.values())
+            {
+                if (extension.equals(format.getExtension()))
+                {
+                    return format;
+                }
+            }
+            throw new IllegalArgumentException(extension + ": invalid config extension");
+        }
+    }
+
+    void load(File file) throws IOException;
+
+    void load(InputStream inputStream, ConfigFormat format);
+
+    boolean isSupportedFormat(ConfigFormat format);
+
+    String getProperty(String key);
+
+    void setProperty(String key, String value);
+
+    Set<String> stringPropertyNames();
+}

--- a/src/main/java/org/kairosdb/core/KairosConfigImpl.java
+++ b/src/main/java/org/kairosdb/core/KairosConfigImpl.java
@@ -1,0 +1,69 @@
+package org.kairosdb.core;
+
+import com.typesafe.config.*;
+
+import java.io.*;
+import java.util.*;
+
+public class KairosConfigImpl extends HashMap<String, String> implements KairosConfig
+{
+    private static final Set<ConfigFormat> supportedFormats = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
+            ConfigFormat.PROPERTIES, ConfigFormat.JSON, ConfigFormat.HOCON)));
+
+    @Override
+    public void load(File file) throws IOException
+    {
+        try (InputStream is = new FileInputStream(file))
+        {
+            load(is, ConfigFormat.fromFileName(file.getName()));
+        }
+    }
+
+    @Override
+    public void load(InputStream inputStream, ConfigFormat format)
+    {
+        if (!isSupportedFormat(format))
+        {
+            throw new IllegalArgumentException("Config format is not supported: " + format.toString());
+        }
+
+        Reader reader = new InputStreamReader(inputStream);
+        Config config = ConfigFactory.parseReader(reader, getParseOptions(format));
+
+        for (Map.Entry<String, ConfigValue> entry : config.entrySet())
+        {
+            String value = (String)entry.getValue().unwrapped();
+            put(entry.getKey(), value);
+        }
+    }
+
+    private ConfigParseOptions getParseOptions(ConfigFormat format)
+    {
+        ConfigSyntax syntax = ConfigSyntax.valueOf(format.getExtension().toUpperCase());
+        return ConfigParseOptions.defaults().setSyntax(syntax);
+    }
+
+    @Override
+    public boolean isSupportedFormat(ConfigFormat format)
+    {
+        return supportedFormats.contains(format);
+    }
+
+    @Override
+    public String getProperty(String key)
+    {
+        return get(key);
+    }
+
+    @Override
+    public void setProperty(String key, String value)
+    {
+        put(key, value);
+    }
+
+    @Override
+    public Set<String> stringPropertyNames()
+    {
+        return keySet();
+    }
+}

--- a/src/main/java/org/kairosdb/core/http/WebServletModule.java
+++ b/src/main/java/org/kairosdb/core/http/WebServletModule.java
@@ -22,17 +22,16 @@ import com.google.inject.servlet.GuiceFilter;
 import com.sun.jersey.guice.JerseyServletModule;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
 import org.eclipse.jetty.servlets.GzipFilter;
-import org.kairosdb.core.http.exceptionmapper.InvalidServerTypeExceptionMapper;
+import org.kairosdb.core.KairosConfig;
 import org.kairosdb.core.http.rest.FeaturesResource;
 import org.kairosdb.core.http.rest.MetadataResource;
 import org.kairosdb.core.http.rest.MetricsResource;
 
 import javax.ws.rs.core.MediaType;
-import java.util.Properties;
 
 public class WebServletModule extends JerseyServletModule
 {
-	public WebServletModule(Properties props)
+	public WebServletModule(KairosConfig props)
 	{
 	}
 
@@ -66,7 +65,6 @@ public class WebServletModule extends JerseyServletModule
 		bind(JacksonJsonProvider.class).in(Scopes.SINGLETON);
 		serve("/*").with(GuiceContainer.class);
 
-		//
-		bind(InvalidServerTypeExceptionMapper.class).in(Scopes.SINGLETON);
+
 	}
 }

--- a/src/main/java/org/kairosdb/core/oauth/OAuthModule.java
+++ b/src/main/java/org/kairosdb/core/oauth/OAuthModule.java
@@ -17,9 +17,9 @@
 package org.kairosdb.core.oauth;
 
 import com.google.inject.servlet.ServletModule;
+import org.kairosdb.core.KairosConfig;
 
 import javax.inject.Singleton;
-import java.util.Properties;
 
 public class OAuthModule extends ServletModule
 {
@@ -27,18 +27,16 @@ public class OAuthModule extends ServletModule
 
 	private ConsumerTokenStore m_tokenStore;
 
-	public OAuthModule(Properties props)
+	public OAuthModule(KairosConfig props)
 	{
 		m_tokenStore = new ConsumerTokenStore();
 
-		for (Object key : props.keySet())
+		for (String key : props.keySet())
 		{
-			String strKey = (String)key;
-
-			if (strKey.startsWith(CONSUMER_PREFIX))
+			if (key.startsWith(CONSUMER_PREFIX))
 			{
-				String consumerKey = strKey.substring(CONSUMER_PREFIX.length());
-				String consumerToken = (String)props.get(key);
+				String consumerKey = key.substring(CONSUMER_PREFIX.length());
+				String consumerToken = props.get(key);
 
 				m_tokenStore.addToken(consumerKey, consumerToken);
 			}

--- a/src/main/java/org/kairosdb/core/telnet/TelnetServerModule.java
+++ b/src/main/java/org/kairosdb/core/telnet/TelnetServerModule.java
@@ -18,16 +18,15 @@ package org.kairosdb.core.telnet;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Singleton;
+import org.kairosdb.core.KairosConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Properties;
 
 public class TelnetServerModule extends AbstractModule
 {
 	public static final Logger logger = LoggerFactory.getLogger(TelnetServerModule.class);
 
-	public TelnetServerModule(Properties props)
+	public TelnetServerModule(KairosConfig props)
 	{
 
 	}

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraModule.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraModule.java
@@ -16,35 +16,21 @@
 
 package org.kairosdb.datastore.cassandra;
 
-import com.datastax.driver.core.ConsistencyLevel;
-import com.datastax.driver.core.Session;
-import com.datastax.driver.core.policies.LoadBalancingPolicy;
 import com.google.inject.AbstractModule;
-import com.google.inject.Provides;
+import com.google.inject.Scope;
 import com.google.inject.Scopes;
-import com.google.inject.Singleton;
 import com.google.inject.TypeLiteral;
-import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Names;
-import org.kairosdb.core.DataPoint;
+import org.kairosdb.core.KairosConfig;
 import org.kairosdb.core.datastore.Datastore;
 import org.kairosdb.core.datastore.ServiceKeyStore;
-import org.kairosdb.core.queue.EventCompletionCallBack;
-import org.kairosdb.events.DataPointEvent;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import javax.inject.Named;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.SortedMap;
 
 public class CassandraModule extends AbstractModule
 {
-	public static final Logger logger = LoggerFactory.getLogger(CassandraModule.class);
-
 	public static final String CASSANDRA_AUTH_MAP = "cassandra.auth.map";
 	public static final String CASSANDRA_HECTOR_MAP = "cassandra.hector.map";
 	public static final String AUTH_PREFIX = "kairosdb.datastore.cassandra.auth.";
@@ -53,22 +39,20 @@ public class CassandraModule extends AbstractModule
 	private Map<String, String> m_authMap = new HashMap<String, String>();
 	private Map<String, Object> m_hectorMap = new HashMap<String, Object>();
 
-	public CassandraModule(Properties props)
+	public CassandraModule(KairosConfig props)
 	{
-		for (Object key : props.keySet())
+		for (String key : props.keySet())
 		{
-			String strKey = (String)key;
-
-			if (strKey.startsWith(AUTH_PREFIX))
+			if (key.startsWith(AUTH_PREFIX))
 			{
-				String consumerKey = strKey.substring(AUTH_PREFIX.length());
-				String consumerToken = (String)props.get(key);
+				String consumerKey = key.substring(AUTH_PREFIX.length());
+				String consumerToken = props.get(key);
 
 				m_authMap.put(consumerKey, consumerToken);
 			}
-			else if (strKey.startsWith(HECTOR_PREFIX))
+			else if (key.startsWith(HECTOR_PREFIX))
 			{
-				String configKey = strKey.substring(HECTOR_PREFIX.length());
+				String configKey = key.substring(HECTOR_PREFIX.length());
 				m_hectorMap.put(configKey, props.get(key));
 			}
 		}
@@ -83,113 +67,13 @@ public class CassandraModule extends AbstractModule
 		bind(CassandraDatastore.class).in(Scopes.SINGLETON);
 		bind(CleanRowKeyCache.class).in(Scopes.SINGLETON);
 		bind(CassandraConfiguration.class).in(Scopes.SINGLETON);
-		//bind(CassandraClient.class).to(CassandraClientImpl.class);
+		bind(CassandraClient.class).to(CassandraClientImpl.class);
 		bind(CassandraClientImpl.class).in(Scopes.SINGLETON);
-		bind(BatchStats.class).in(Scopes.SINGLETON);
 
 		bind(new TypeLiteral<Map<String, String>>(){}).annotatedWith(Names.named(CASSANDRA_AUTH_MAP))
 				.toInstance(m_authMap);
 
-		/*bind(new TypeLiteral<Map<String, Object>>(){}).annotatedWith(Names.named(CASSANDRA_HECTOR_MAP))
-				.toInstance(m_hectorMap);*/
-
-
-		install(new FactoryModuleBuilder().build(BatchHandlerFactory.class));
-
-		install(new FactoryModuleBuilder().build(DeleteBatchHandlerFactory.class));
-
-		install(new FactoryModuleBuilder().build(CQLBatchFactory.class));
+		bind(new TypeLiteral<Map<String, Object>>(){}).annotatedWith(Names.named(CASSANDRA_HECTOR_MAP))
+				.toInstance(m_hectorMap);
 	}
-
-	@Provides
-	@Named("keyspace")
-	String getKeyspace(CassandraConfiguration configuration)
-	{
-		return configuration.getKeyspaceName();
-	}
-
-	@Provides
-	@Singleton
-	CassandraClient getCassandraClient(CassandraConfiguration configuration)
-	{
-		try
-		{
-			return new CassandraClientImpl(configuration);
-		}
-		catch (Exception e)
-		{
-			logger.error("Unable to setup cassandra connection to cluster", e);
-			throw e;
-		}
-	}
-
-	@Provides
-	@Singleton
-	Schema getCassandraSchema(CassandraClient cassandraClient)
-	{
-		try
-		{
-			return new Schema(cassandraClient);
-		}
-		catch (Exception e)
-		{
-			logger.error("Unable to setup cassandra schema", e);
-			throw e;
-		}
-	}
-
-	@Provides
-	@Singleton
-	LoadBalancingPolicy getLoadBalancingPolicy(CassandraClient cassandraClient)
-	{
-		return cassandraClient.getLoadBalancingPolicy();
-	}
-
-	@Provides
-	@Singleton
-	ConsistencyLevel getWriteConsistencyLevel(CassandraConfiguration configuration)
-	{
-		return configuration.getDataWriteLevel();
-	}
-
-	@Provides
-	@Singleton
-	Session getCassandraSession(Schema schema)
-	{
-		return schema.getSession();
-	}
-
-
-	@Provides
-	@Singleton
-	DataCache<DataPointsRowKey> getRowKeyCache(CassandraConfiguration configuration)
-	{
-		return new DataCache<>(configuration.getRowKeyCacheSize());
-	}
-
-	@Provides
-	@Singleton
-	DataCache<String> getMetricNameCache(CassandraConfiguration configuration)
-	{
-		return new DataCache<>(configuration.getStringCacheSize());
-	}
-
-	public interface BatchHandlerFactory
-	{
-		BatchHandler create(List<DataPointEvent> events, EventCompletionCallBack callBack,
-				boolean fullBatch);
-	}
-
-	public interface DeleteBatchHandlerFactory
-	{
-		DeleteBatchHandler create(String metricName, SortedMap<String, String> tags,
-				List<DataPoint> dataPoints, EventCompletionCallBack callBack);
-	}
-
-	public interface CQLBatchFactory
-	{
-		CQLBatch create();
-	}
-
-
 }

--- a/src/main/java/org/kairosdb/eventbus/EventBusConfiguration.java
+++ b/src/main/java/org/kairosdb/eventbus/EventBusConfiguration.java
@@ -1,12 +1,12 @@
 package org.kairosdb.eventbus;
 
 import com.google.inject.Inject;
+import org.kairosdb.core.KairosConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -27,21 +27,20 @@ public class EventBusConfiguration
     private final Map<String, Integer> priorities = new HashMap<>();
 
     @Inject
-    public EventBusConfiguration(Properties properties)
+    public EventBusConfiguration(KairosConfig config)
     {
-        checkNotNull(properties, "properties cannot be null");
+        checkNotNull(config, "properties cannot be null");
 
-        for (Object o : properties.keySet()) {
-            String property = (String) o;
+        for (String property : config.keySet()) {
             if (property.startsWith(KAIROSDB_EVENTBUS_FILTER_PRIORITY_PREFIX))
             {
                 String className = property.substring(property.indexOf(KAIROSDB_EVENTBUS_FILTER_PRIORITY_PREFIX) + PREFIX_LENGTH);
                 try {
-                    int priority = Integer.parseInt(properties.getProperty(property));
+                    int priority = Integer.parseInt(config.getProperty(property));
                     priorities.put(className, priority);
                 }
                 catch (NumberFormatException e) {
-                    logger.error("Priority is invalid " + properties.getProperty(property));
+                    logger.error("Priority is invalid " + config.getProperty(property));
                 }
             }
         }

--- a/src/main/resources/kairosdb.properties
+++ b/src/main/resources/kairosdb.properties
@@ -51,10 +51,6 @@ kairosdb.jetty.static_web_root=webroot
 #kairosdb.jetty.threads.max=2500
 #kairosdb.jetty.threads.keep_alive_ms=10000
 
-# To set the traffic type allowed for the server, change the kairosdb.server.type entry to INGEST, QUERY, or DELETE,
-# or a comma delimited list of two of them to enable different sets of API methods.
-# The default setting is ALL, which will enable all API methods.
-#kairosdb.server.type=ALL
 
 #===============================================================================
 kairosdb.service.datastore=org.kairosdb.datastore.h2.H2Module
@@ -73,24 +69,10 @@ kairosdb.datastore.h2.database_path=build/h2db
 kairosdb.datastore.cassandra.cql_host_list=localhost
 kairosdb.datastore.cassandra.keyspace=kairosdb
 
-#Sets the replication for the keyspace.  This is only used the first time Kairos
-#starts up and needs to create the schema in Cassandra.  Later changes
-#to this property have no effect.
-kairosdb.datastore.cassandra.replication={'class': 'SimpleStrategy','replication_factor' : 1}
-
 #For a single metric query this dictates the number of simultaneous cql queries
-#to run (ie one for each partition key of data).  The larger the cluster the higher you may want
+#to run (ie one for each row of data).  The larger the cluster the higher you may want
 #this number to be.
-kairosdb.datastore.cassandra.simultaneous_cql_queries=20
-
-# query_reader_threads is the number of threads to use to read results from
-# each cql query.  You may want to change this number depending on your environment
-kairosdb.datastore.cassandra.query_reader_threads=6
-
-# When set, the query_limit will prevent any query reading more than the specified
-# number of data points.  When the limit is reached an exception is thrown and an
-# error is returned to the client.  Set this value to 0 to disable (default)
-#kairosdb.datastore.cassandra.query_limit=10000000
+kairosdb.datastore.cassandra.simultaneous_cql_queries=100
 
 #Size of the row key cache size.  This can be monitored by querying
 #kairosdb.datastore.write_size and filtering on the tag buffer = row_key_index
@@ -106,9 +88,6 @@ kairosdb.datastore.cassandra.string_cache_size=50000
 kairosdb.datastore.cassandra.read_consistency_level=ONE
 kairosdb.datastore.cassandra.write_consistency_level=QUORUM
 
-# Set this if this kairosdb node connects to cassandra nodes in multiple datacenters.
-# Not setting this will select cassandra hosts using the RoundRobinPolicy, while setting this will use DCAwareRoundRobinPolicy.
-#kairosdb.datastore.cassandra.local_datacenter=
 
 kairosdb.datastore.cassandra.connections_per_host.local.core=5
 kairosdb.datastore.cassandra.connections_per_host.local.max=100
@@ -124,33 +103,14 @@ kairosdb.datastore.cassandra.max_queue_size=500
 #for cassandra authentication use the following
 #kairosdb.datastore.cassandra.auth.[prop name]=[prop value]
 #example:
-#kairosdb.datastore.cassandra.auth.user_name=admin
+#kairosdb.datastore.cassandra.auth.username=admin
 #kairosdb.datastore.cassandra.auth.password=eat_me
-
-# Set this property to true to enable SSL connections to your C* cluster.
-# Follow the instructions found here: http://docs.datastax.com/en/developer/java-driver/3.1/manual/ssl/
-# to create a keystore and pass the values into Kairos using the -D switches
-kairosdb.datastore.cassandra.use_ssl=false
 
 #the time to live in seconds for datapoints. After this period the data will be
 #deleted automatically. If not set the data will live forever.
 #TTLs are added to columns as they're inserted so setting this will not affect
 #existing data, only new data.
 #kairosdb.datastore.cassandra.datapoint_ttl=31536000
-
-# Set this property to true to align each datapoint ttl with its timestamp.
-# example: datapoint_ttl is set to 30 days; ingesting a datapoint with timestamp '25 days ago'
-#   - Without this setting, the datapoint will be stored for 30 days from now on, so it can be queried for 30 + 25 days which may not be the intended behaviour using a 30 days ttl
-#   - Setting this property to true will only store this datapoint for 5 days (30 - 25 days).
-# default: false
-# Additional note: consider setting force_default_datapoint_ttl as well for full control
-kairosdb.datastore.cassandra.align_datapoint_ttl_with_timestamp=false
-
-# Set this property to true to force the default datapoint_ttl for all ingested datapoints, effectively ignoring their ttl informations if they provide them.
-# This gives you full control over the timespan the datapoints are stored in K*.
-# default: false
-# Additional note: consider setting align_datapoint_ttl_with_timestamp as well for full control
-kairosdb.datastore.cassandra.force_default_datapoint_ttl=false
 
 #===============================================================================
 # Remote datastore properties
@@ -174,8 +134,8 @@ kairosdb.datastore.remote.schedule=0 */30 * * * ?
 # delay up to 10 minutes.
 kairosdb.datastore.remote.random_delay=0
 
-# Optional prefix filter for remote module. If present, only metrics that start with the
-# values in this comma-separated list are forwarded on.
+# Optional prefix filter for remote module.  Only metrics that start with this
+# value are forwarded on.
 #kairosdb.datastore.remote.prefix_filter=
 
 #===============================================================================
@@ -222,9 +182,11 @@ kairosdb.log.queries.greater_than=60
 # from inserting data witch each query
 kairosdb.queries.aggregate_stats=false
 
+
 #===============================================================================
 # Health Checks
 kairosdb.service.health=org.kairosdb.core.health.HealthCheckModule
+#kairosdb.service.rollups=org.kairosdb.rollup.RollUpModule
 
 #Response code to return from a call to /api/v1/health/check
 #Some load balancers want 200 instead of 204
@@ -283,50 +245,3 @@ kairosdb.queue_processor.page_size=52428800
 #Number of threads allowed to insert data to the backend
 #CassandraDatastore is the only use of this executor
 kairosdb.ingest_executor.thread_count=10
-
-#===============================================================================
-# Roll-ups
-#kairosdb.service.rollups=org.kairosdb.rollup.RollUpModule
-
-# How often the Roll-up Manager queries for new or updated roll-ups
-#kairosdb.rollups.server_assignment.check_update_delay_millseconds=10000
-#===============================================================================
-
-#===============================================================================
-# Host Manager Service
-
-# How often the host service checks for active hosts
-kairosdb.host_service_manager.check_delay_time_millseconds=60000
-
-# How long before a host is considered inactive
-kairosdb.host_service_manager.inactive_time_seconds=300
-#===============================================================================
-
-#===============================================================================
-#Demo and stress modules
-
-# The demo module will load one years of data into kairos.  The code goes back
-# one year from the present and inserts data every minute.  The data makes a
-# pretty little sign wave.
-
-#kairosdb.service.demo=org.kairosdb.core.demo.DemoModule
-kairosdb.demo.metric_name=demo_data
-# number of rows = number of host tags to add to the data. Setting the number_of_rows
-# to 100 means 100 hosts reporting data every minutes, each host has a different tag.
-kairosdb.demo.number_of_rows=100
-kairosdb.demo.ttl=0
-
-
-# This just inserts data as fast as it can for the duration specified.  Good for
-# stress testing your backend.  I have found that a single Kairos node will only
-# send about 500k/sec because of a limitation in the cassandra client.
-
-#kairosdb.service.blast=org.kairosdb.core.blast.BlastModule
-# The number_of_rows translates into a random number between 0 and number_of_rows
-# that is added as a tag to each data point.  Trying to simulate a even distribution
-# data in the cluster.
-kairosdb.blast.number_of_rows=1000
-kairosdb.blast.duration_seconds=30
-kairosdb.blast.metric_name=blast_load
-kairosdb.blast.ttl=600
-

--- a/src/test/java/org/kairosdb/core/ConfigFormatTest.java
+++ b/src/test/java/org/kairosdb/core/ConfigFormatTest.java
@@ -1,0 +1,44 @@
+package org.kairosdb.core;
+
+import org.junit.Test;
+
+import static org.kairosdb.core.KairosConfig.ConfigFormat;
+import static org.junit.Assert.*;
+
+public class ConfigFormatTest {
+    @Test
+    public void getExtension() throws Exception
+    {
+        assertEquals("properties", ConfigFormat.PROPERTIES.getExtension());
+        assertEquals("json", ConfigFormat.JSON.getExtension());
+        assertEquals("conf", ConfigFormat.HOCON.getExtension());
+    }
+
+    @Test
+    public void fromFileName() throws Exception
+    {
+        assertEquals(ConfigFormat.PROPERTIES, ConfigFormat.fromFileName("config.properties"));
+        assertEquals(ConfigFormat.JSON, ConfigFormat.fromFileName("config.json"));
+        assertEquals(ConfigFormat.HOCON, ConfigFormat.fromFileName("config.conf"));
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void fromFileName_withInvalidFileType() throws Exception
+    {
+        ConfigFormat.fromFileName("config.yaml");
+    }
+
+    @Test
+    public void fromExtension() throws Exception
+    {
+        assertEquals(ConfigFormat.PROPERTIES, ConfigFormat.fromExtension("properties"));
+        assertEquals(ConfigFormat.JSON, ConfigFormat.fromExtension("json"));
+        assertEquals(ConfigFormat.HOCON, ConfigFormat.fromExtension("conf"));
+    }
+
+    @Test (expected = IllegalArgumentException.class)
+    public void fromExtension_withInvalidExtension() throws Exception
+    {
+        ConfigFormat.fromExtension("yaml");
+    }
+}

--- a/src/test/java/org/kairosdb/core/KairosConfigImplTest.java
+++ b/src/test/java/org/kairosdb/core/KairosConfigImplTest.java
@@ -1,0 +1,272 @@
+package org.kairosdb.core;
+
+import com.google.common.io.Resources;
+import com.typesafe.config.ConfigException;
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.*;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.kairosdb.core.KairosConfig.ConfigFormat;
+import static org.junit.Assert.*;
+
+public class KairosConfigImplTest {
+
+    private static final String PROPERITES_CONFIG_FILE = "config.properties";
+    private static final String JSON_CONFIG_FILE = "config.json";
+    private static final String HOCON_CONFIG_FILE = "config.conf";
+
+    private static final String RESERVED_HOCON_CHARS = "${}[]:+=#`^?!@*// ";
+
+    private static Map<String, String> defaultProperties;
+    private static Map<String, String> properties;
+
+    @BeforeClass
+    public static void setupClass() {
+        Map<String, String> map = new HashMap<>();
+        map.put("key1", "default_value1");
+        map.put("key3", "default_value2");
+        map.put("object.key1", "default_value3");
+        map.put("object.key3", "default_value4");
+        map.put("object.inner_object.key1", "default_value5");
+        map.put("object.inner_object.key3", "default_value6");
+        defaultProperties = Collections.unmodifiableMap(map);
+
+        map = new HashMap<>();
+        map.put("key1", "value1");
+        map.put("key2", "value2");
+        map.put("object.key1", "value3");
+        map.put("object.key2", "value4");
+        map.put("object.inner_object.key1", "value5");
+        map.put("object.inner_object.key2", "value6");
+        properties = Collections.unmodifiableMap(map);
+    }
+
+    private static Map<String,String> merge(Map<String,String> map1, Map<String,String> map2) {
+        Map<String,String> mergedMap = new HashMap<>();
+        mergedMap.putAll(map1);
+        mergedMap.putAll(map2);
+        return mergedMap;
+    }
+
+    private KairosConfig m_config;
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @Before
+    public void setup()
+    {
+        this.m_config = new KairosConfigImpl();
+    }
+
+    private File getFile(String fileName) throws URISyntaxException
+    {
+        URL url = Resources.getResource(fileName);
+        return Paths.get(url.toURI()).toFile();
+    }
+
+    private File makeFile(String fileName, String content) throws IOException
+    {
+        final File file = tempFolder.newFile(fileName);
+        try(PrintWriter out = new PrintWriter(file))
+        {
+            out.write(content);
+        }
+        return file;
+    }
+
+    @Test
+    public void test_getProperty()
+    {
+        m_config.put("key", "value");
+        assertEquals("value", m_config.getProperty("key"));
+    }
+
+    @Test
+    public void test_getProperty_shouldReturnUpdatedValue()
+    {
+        m_config.put("key", "initialValue");
+        m_config.put("key", "updatedValue");
+        assertEquals("updatedValue", m_config.getProperty("key"));
+    }
+
+    @Test
+    public void test_getProperty_shouldReturnNull()
+    {
+        assertNull(m_config.getProperty("key"));
+    }
+
+    @Test
+    public void test_setProperty()
+    {
+        m_config.setProperty("key", "value");
+        assertEquals("value", m_config.get("key"));
+    }
+
+    @Test
+    public void test_setProperty_shouldUpdateExistingProperty()
+    {
+        m_config.setProperty("key", "initialValue");
+        m_config.setProperty("key", "updatedValue");
+        assertEquals("updatedValue", m_config.get("key"));
+    }
+
+    @Test
+    public void test_stringPropertyNames()
+    {
+        m_config.putAll(defaultProperties);
+        assertEquals(defaultProperties.keySet(), m_config.stringPropertyNames());
+    }
+
+    @Test
+    public void test_load_propertiesFile() throws IOException, URISyntaxException
+    {
+        m_config.load(getFile(PROPERITES_CONFIG_FILE));
+        assertEquals(properties, m_config);
+    }
+
+    @Test
+    public void test_load_JSONFile() throws IOException, URISyntaxException
+    {
+        m_config.load(getFile(JSON_CONFIG_FILE));
+        assertEquals(properties, m_config);
+    }
+
+    @Test
+    public void test_load_HOCONFile() throws IOException, URISyntaxException
+    {
+        m_config.load(getFile(HOCON_CONFIG_FILE));
+        assertEquals(properties, m_config);
+    }
+
+    @Test
+    public void test_load_propertiesStream() throws IOException
+    {
+        try (InputStream is = Resources.getResource(PROPERITES_CONFIG_FILE).openStream())
+        {
+            m_config.load(is, ConfigFormat.PROPERTIES);
+        }
+        assertEquals(properties, m_config);
+    }
+
+    @Test
+    public void test_load_JSONStream() throws IOException
+    {
+        try (InputStream is = Resources.getResource(JSON_CONFIG_FILE).openStream())
+        {
+            m_config.load(is, ConfigFormat.JSON);
+        }
+        assertEquals(properties, m_config);
+    }
+
+    @Test
+    public void test_load_HOCONStream() throws IOException
+    {
+        try (InputStream is = Resources.getResource(HOCON_CONFIG_FILE).openStream())
+        {
+            m_config.load(is, ConfigFormat.HOCON);
+        }
+        assertEquals(properties, m_config);
+    }
+
+    @Test
+    public void test_load_file_shouldOverrideExistingProperties() throws IOException, URISyntaxException
+    {
+        m_config.putAll(defaultProperties);
+        m_config.load(getFile(HOCON_CONFIG_FILE));
+
+        Map<String, String> expectedProperties = merge(defaultProperties, properties);
+        assertEquals(expectedProperties, m_config);
+    }
+
+    @Test
+    public void test_load_stream_shouldOverrideExistingProperties() throws IOException
+    {
+        m_config.putAll(defaultProperties);
+        try (InputStream is = Resources.getResource(HOCON_CONFIG_FILE).openStream())
+        {
+            m_config.load(is, ConfigFormat.HOCON);
+        }
+
+        Map<String, String> expectedProperties = merge(defaultProperties, properties);
+        assertEquals(expectedProperties, m_config);
+    }
+
+    @Test
+    public void test_load_file_shouldUsePropertiesFormat() throws IOException
+    {
+        // Loading config data that is only valid using Java Properties format
+        String configString = "key=" + RESERVED_HOCON_CHARS;
+        m_config.load(makeFile("temp.properties", configString));
+    }
+
+    @Test(expected = ConfigException.Parse.class)
+    public void test_load_file_shouldUseJSONFormat() throws IOException
+    {
+        // Loading config data that is only invalid using JSON format
+        String configString = "key=value";
+        m_config.load(makeFile("temp.json", configString));
+    }
+
+    @Test
+    public void test_load_file_shouldUseHOCONFormat() throws IOException
+    {
+        // Loading config data that is only valid using HOCON format
+        String configString = "{key: value}";
+        m_config.load(makeFile("temp.conf", configString));
+        assertEquals("value", m_config.getProperty("key"));
+    }
+
+    @Test
+    public void test_load_stream_shouldUsePropertiesFormat() throws IOException
+    {
+        // Loading config data that is only valid using Java Properties format
+        String config = "key=" + RESERVED_HOCON_CHARS;
+        try(InputStream is = IOUtils.toInputStream(config, "UTF-8"))
+        {
+            m_config.load(is, ConfigFormat.PROPERTIES);
+        }
+    }
+
+    @Test(expected = ConfigException.Parse.class)
+    public void test_load_stream_shouldUseJSONFormat() throws IOException
+    {
+        // Loading config data that is only invalid using JSON format
+        String config = "key=value";
+        try(InputStream is = IOUtils.toInputStream(config, "UTF-8"))
+        {
+            m_config.load(is, ConfigFormat.JSON);
+        }
+    }
+
+    @Test
+    public void test_load_stream_shouldUseHOCONFormat() throws IOException
+    {
+        // Loading config data that is only valid using HOCON format
+        String config = "{key: value}";
+        try(InputStream is = IOUtils.toInputStream(config, "UTF-8"))
+        {
+            m_config.load(is, ConfigFormat.HOCON);
+        }
+        assertEquals("value", m_config.getProperty("key"));
+    }
+
+    @Test
+    public void isSupportedFormat()
+        {
+        assertTrue(m_config.isSupportedFormat(KairosConfig.ConfigFormat.PROPERTIES));
+        assertTrue(m_config.isSupportedFormat(KairosConfig.ConfigFormat.JSON));
+        assertTrue(m_config.isSupportedFormat(KairosConfig.ConfigFormat.HOCON));
+    }
+}

--- a/src/test/java/org/kairosdb/core/aggregator/TestAggregatorFactory.java
+++ b/src/test/java/org/kairosdb/core/aggregator/TestAggregatorFactory.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.AbstractModule;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
+import org.kairosdb.core.KairosConfigImpl;
 import org.kairosdb.core.annotation.Feature;
 import org.kairosdb.core.annotation.FeatureComponent;
 import org.kairosdb.core.datapoints.DoubleDataPointFactory;
@@ -28,12 +29,11 @@ import org.kairosdb.core.exception.KairosDBException;
 import org.kairosdb.core.processingstage.FeatureProcessingFactory;
 import org.kairosdb.core.processingstage.metadata.FeatureProcessorMetadata;
 import org.kairosdb.eventbus.EventBusConfiguration;
-import org.kairosdb.eventbus.FilterEventBus;
+import org.kairosdb.eventbus.EventBusWithFilters;
 import org.kairosdb.plugin.Aggregator;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 @Feature(
 		name = "aggregators",
@@ -64,7 +64,7 @@ public class TestAggregatorFactory implements FeatureProcessingFactory<Aggregato
 			protected void configure()
 			{
 				bind(DoubleDataPointFactory.class).to(DoubleDataPointFactoryImpl.class);
-				bind(FilterEventBus.class).toInstance(new FilterEventBus(new EventBusConfiguration(new Properties())));
+				bind(EventBusWithFilters.class).toInstance(new EventBusWithFilters(new EventBusConfiguration(new KairosConfigImpl())));
 
 				for (Class<?> aggregator : aggregators.values())
 				{

--- a/src/test/java/org/kairosdb/core/http/rest/json/QueryParserTest.java
+++ b/src/test/java/org/kairosdb/core/http/rest/json/QueryParserTest.java
@@ -22,6 +22,7 @@ import com.google.common.io.Resources;
 import org.joda.time.DateTimeZone;
 import org.junit.Before;
 import org.junit.Test;
+import org.kairosdb.core.KairosConfigImpl;
 import org.kairosdb.core.KairosFeatureProcessor;
 import org.kairosdb.core.aggregator.*;
 import org.kairosdb.core.datapoints.DoubleDataPointFactoryImpl;
@@ -34,14 +35,13 @@ import org.kairosdb.core.groupby.TestGroupByFactory;
 import org.kairosdb.core.http.rest.BeanValidationException;
 import org.kairosdb.core.http.rest.QueryException;
 import org.kairosdb.eventbus.EventBusConfiguration;
-import org.kairosdb.eventbus.FilterEventBus;
+import org.kairosdb.eventbus.EventBusWithFilters;
 import org.kairosdb.plugin.Aggregator;
 import org.kairosdb.rollup.Rollup;
 import org.kairosdb.rollup.RollupTask;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Properties;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -50,13 +50,13 @@ import static org.junit.Assert.fail;
 public class QueryParserTest
 {
 	private QueryParser parser;
-	private FilterEventBus eventBus;
+	private EventBusWithFilters eventBus;
 
 	@Before
 	public void setup() throws KairosDBException
 	{
 		parser = new QueryParser(new KairosFeatureProcessor(new TestAggregatorFactory(), new TestGroupByFactory()), new TestQueryPluginFactory());
-		eventBus = new FilterEventBus(new EventBusConfiguration(new Properties()));
+		eventBus = new EventBusWithFilters(new EventBusConfiguration(new KairosConfigImpl()));
 	}
 
 	@Test

--- a/src/test/java/org/kairosdb/core/oauth/OAuthModuleTest.java
+++ b/src/test/java/org/kairosdb/core/oauth/OAuthModuleTest.java
@@ -17,8 +17,8 @@
 package org.kairosdb.core.oauth;
 
 import org.junit.Test;
-
-import java.util.Properties;
+import org.kairosdb.core.KairosConfig;
+import org.kairosdb.core.KairosConfigImpl;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -28,7 +28,7 @@ public class OAuthModuleTest
 	@Test
 	public void testReadingProperties()
 	{
-		Properties props = new Properties();
+		KairosConfig props = new KairosConfigImpl();
 
 		props.put("kairosdb.oauth.consumer.cust1", "ABC123");
 		props.put("kairosdb.oauth.consumerNot.cust1", "XYZ");

--- a/src/test/java/org/kairosdb/core/telnet/PutCommandTest.java
+++ b/src/test/java/org/kairosdb/core/telnet/PutCommandTest.java
@@ -15,6 +15,7 @@
  */
 package org.kairosdb.core.telnet;
 
+import com.google.common.eventbus.Subscribe;
 import org.jboss.netty.channel.Channel;
 import org.jboss.netty.channel.ChannelConfig;
 import org.jboss.netty.channel.ChannelFactory;
@@ -24,6 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kairosdb.core.DataPoint;
 import org.kairosdb.core.DataPointSet;
+import org.kairosdb.core.KairosConfigImpl;
 import org.kairosdb.core.datapoints.DoubleDataPointFactoryImpl;
 import org.kairosdb.core.datapoints.LongDataPointFactoryImpl;
 import org.kairosdb.core.datastore.Datastore;
@@ -32,15 +34,13 @@ import org.kairosdb.core.datastore.QueryCallback;
 import org.kairosdb.core.datastore.TagSet;
 import org.kairosdb.core.exception.DatastoreException;
 import org.kairosdb.eventbus.EventBusConfiguration;
-import org.kairosdb.eventbus.FilterEventBus;
-import org.kairosdb.eventbus.Subscribe;
+import org.kairosdb.eventbus.EventBusWithFilters;
 import org.kairosdb.events.DataPointEvent;
 import org.kairosdb.util.ValidationException;
 
 import javax.annotation.Nullable;
 import java.net.SocketAddress;
 import java.util.Collections;
-import java.util.Properties;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.junit.Assert.assertThat;
@@ -54,7 +54,7 @@ public class PutCommandTest
 	@Before
 	public void setup() throws DatastoreException
 	{
-		FilterEventBus eventBus = new FilterEventBus(new EventBusConfiguration(new Properties()));
+		EventBusWithFilters eventBus = new EventBusWithFilters(new EventBusConfiguration(new KairosConfigImpl()));
 		m_datastore = new FakeDatastore();
 		eventBus.register(m_datastore);
 
@@ -365,7 +365,7 @@ public class PutCommandTest
 		}*/
 
 		@Override
-		public Iterable<String> getMetricNames(String prefix) throws DatastoreException
+		public Iterable<String> getMetricNames() throws DatastoreException
 		{
 			return null;
 		}

--- a/src/test/java/org/kairosdb/datastore/DatastoreTestHelper.java
+++ b/src/test/java/org/kairosdb/datastore/DatastoreTestHelper.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.SetMultimap;
 import com.google.common.collect.TreeMultimap;
 import org.junit.Test;
+import org.kairosdb.core.KairosConfigImpl;
 import org.kairosdb.core.datapoints.LongDataPoint;
 import org.kairosdb.core.datapoints.StringDataPoint;
 import org.kairosdb.core.datastore.DataPointGroup;
@@ -30,15 +31,13 @@ import org.kairosdb.core.datastore.QueryMetric;
 import org.kairosdb.core.exception.DatastoreException;
 import org.kairosdb.core.groupby.TagGroupBy;
 import org.kairosdb.eventbus.EventBusConfiguration;
-import org.kairosdb.eventbus.FilterEventBus;
-import org.kairosdb.eventbus.Publisher;
+import org.kairosdb.eventbus.EventBusWithFilters;
 import org.kairosdb.events.DataPointEvent;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import java.util.TreeMap;
 
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -51,7 +50,7 @@ import static org.junit.Assert.assertFalse;
 public abstract class DatastoreTestHelper
 {
 	protected static KairosDatastore s_datastore;
-	protected static FilterEventBus s_eventBus = new FilterEventBus(new EventBusConfiguration(new Properties()));
+	protected static EventBusWithFilters s_eventBus = new EventBusWithFilters(new EventBusConfiguration(new KairosConfigImpl()));
 	protected static final List<String> metricNames = new ArrayList<>();
 	private static long s_startTime;
 	private static String s_unicodeNameWithSpace = "你好 means hello";
@@ -97,13 +96,11 @@ public abstract class DatastoreTestHelper
 				.put("month", "April")
 				.build();
 
-		Publisher<DataPointEvent> publisher = s_eventBus.createPublisher(DataPointEvent.class);
-
 		s_startTime = System.currentTimeMillis();
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime, 1)));
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 1000, 2)));
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 2000, 3)));
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 3000, 4)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime, 1)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 1000, 2)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 2000, 3)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 3000, 4)));
 
 
 		tags = ImmutableSortedMap.<String, String>naturalOrder()
@@ -112,10 +109,10 @@ public abstract class DatastoreTestHelper
 				.put("month", "April")
 				.build();
 
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime, 5)));
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 1000, 6)));
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 2000, 7)));
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 3000, 8)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime, 5)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 1000, 6)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 2000, 7)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 3000, 8)));
 
 
 		tags = ImmutableSortedMap.<String, String>naturalOrder()
@@ -124,10 +121,10 @@ public abstract class DatastoreTestHelper
 				.put("month", "April")
 				.build();
 
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime, 9)));
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 1000, 10)));
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 2000, 11)));
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 3000, 12)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime, 9)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 1000, 10)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 2000, 11)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 3000, 12)));
 
 
 		metricNames.add("metric2");
@@ -138,10 +135,10 @@ public abstract class DatastoreTestHelper
 				.put("month", "April")
 				.build();
 
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime, 13)));
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 1000, 14)));
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 2000, 15)));
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 3000, 16)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime, 13)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 1000, 14)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 2000, 15)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime + 3000, 16)));
 
 
 		metricNames.add("duplicates");
@@ -150,9 +147,9 @@ public abstract class DatastoreTestHelper
 				.put("host", "A")
 				.build();
 
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime, 4)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime, 4)));
 
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime, 42)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime, 42)));
 
 
 		//Testing pre 1970 data points with negative values
@@ -161,11 +158,11 @@ public abstract class DatastoreTestHelper
 		tags = ImmutableSortedMap.<String, String>naturalOrder()
 				.put("host", "A").build();
 
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(-2000000000L, 80)));
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(-1000000000L, 40)));
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(-100L, 20)));
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(0L, 3)));
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(2000000000L, 33)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(-2000000000L, 80)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(-1000000000L, 40)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(-100L, 20)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(0L, 3)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(2000000000L, 33)));
 
 		//Test string data
 		metricName = "string_data";
@@ -173,7 +170,7 @@ public abstract class DatastoreTestHelper
 		tags = ImmutableSortedMap.<String, String>naturalOrder()
 				.put("host", "A").build();
 
-		publisher.post(new DataPointEvent(metricName, tags, new StringDataPoint(s_startTime, "Hello")));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new StringDataPoint(s_startTime, "Hello")));
 
 		//Test unicode string data
 		metricName = "string_data_unicode";
@@ -181,7 +178,7 @@ public abstract class DatastoreTestHelper
 		tags = ImmutableSortedMap.<String, String>naturalOrder()
 				.put("host", "A").build();
 
-		publisher.post(new DataPointEvent(metricName, tags, new StringDataPoint(s_startTime, s_unicodeName)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new StringDataPoint(s_startTime, s_unicodeName)));
 
 
 		//Adding a metric with unicode and spaces
@@ -191,7 +188,7 @@ public abstract class DatastoreTestHelper
 				.put("host", s_unicodeName)
 				.put("space", "space is cool").build();
 
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime, 42)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime, 42)));
 
 
 		//Data that will be deleted in test
@@ -200,28 +197,18 @@ public abstract class DatastoreTestHelper
 		tags = ImmutableSortedMap.<String, String>naturalOrder()
 				.put("ghost", "tag").build();
 
-		publisher.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime, 50)));
+		s_eventBus.post(new DataPointEvent(metricName, tags, new LongDataPoint(s_startTime, 50)));
 	}
 
 	@Test
 	public void test_getMetricNames() throws DatastoreException
 	{
-		List<String> metrics = listFromIterable(s_datastore.getMetricNames(null));
+		List<String> metrics = listFromIterable(s_datastore.getMetricNames());
 
 		assertThat(metrics, hasItem("metric1"));
 		assertThat(metrics, hasItem("metric2"));
 		assertThat(metrics, hasItem("duplicates"));
 		assertThat(metrics, hasItem("old_data"));
-	}
-
-	@Test
-	public void test_getMetricNames_with_prefix() throws DatastoreException
-	{
-		List<String> metrics = listFromIterable(s_datastore.getMetricNames("m"));
-
-		assertThat(metrics, hasItem("metric1"));
-		assertThat(metrics, hasItem("metric2"));
-		assertThat(metrics.size(), equalTo(2));
 	}
 
 	//names and values not being stored

--- a/src/test/java/org/kairosdb/eventbus/EventBusConfigurationTest.java
+++ b/src/test/java/org/kairosdb/eventbus/EventBusConfigurationTest.java
@@ -1,8 +1,8 @@
 package org.kairosdb.eventbus;
 
 import org.junit.Test;
-
-import java.util.Properties;
+import org.kairosdb.core.KairosConfig;
+import org.kairosdb.core.KairosConfigImpl;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -19,7 +19,7 @@ public class EventBusConfigurationTest
     @Test
     public void test()
     {
-        Properties properties = new Properties();
+        KairosConfig properties = new KairosConfigImpl();
         properties.put("kairosdb.eventbus.filter.priority.com.foo.Filter1", "10");
         properties.put("kairosdb.eventbus.filter.priority.com.bar.Filter2", "20");
         properties.put("kairosdb.eventbus.filter.priority.com.fi.Filter3", "30");
@@ -37,7 +37,7 @@ public class EventBusConfigurationTest
     @Test
     public void test_invalid_priority()
     {
-        Properties properties = new Properties();
+        KairosConfig properties = new KairosConfigImpl();
         properties.put("kairosdb.eventbus.filter.priority.com.foo.Filter1", "10.5");
 
         EventBusConfiguration config = new EventBusConfiguration(properties);

--- a/src/test/java/org/kairosdb/eventbus/FilterRegistryTest.java
+++ b/src/test/java/org/kairosdb/eventbus/FilterRegistryTest.java
@@ -1,0 +1,252 @@
+package org.kairosdb.eventbus;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Iterators;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import org.junit.Before;
+import org.junit.Test;
+import org.kairosdb.core.KairosConfigImpl;
+
+import java.util.Iterator;
+import java.util.List;
+
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.fail;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class FilterRegistryTest {
+
+    private FilterRegistry registry;
+
+    @Before
+    public void setup()
+    {
+        registry = new FilterRegistry(new EventBusWithFilters(new EventBusConfiguration(new KairosConfigImpl())));
+    }
+
+    @Test
+    public void testRegister_invalidMethod_noReturnType()
+    {
+        try {
+            registry.register(new InvalidSubscriber());
+            fail("expected an UncheckedExecutionException");
+        }
+        catch(UncheckedExecutionException e) {
+            assertEquals(
+                    "Method public void org.kairosdb.eventbus.FilterRegistryTest$InvalidSubscriber.handle(java.lang.String) must have return type of java.lang.String",
+                    e.getCause().getMessage());
+        }
+    }
+
+    @Test
+    public void testRegister() {
+        assertEquals(0, registry.getSubscribersForTesting(String.class).size());
+
+        registry.register(new StringSubscriber());
+        assertEquals(1, registry.getSubscribersForTesting(String.class).size());
+
+        registry.register(new StringSubscriber());
+        assertEquals(2, registry.getSubscribersForTesting(String.class).size());
+
+        registry.register(new ObjectSubscriber());
+        assertEquals(2, registry.getSubscribersForTesting(String.class).size());
+        assertEquals(1, registry.getSubscribersForTesting(Object.class).size());
+    }
+
+    @Test
+    public void testUnregister() {
+        StringSubscriber s1 = new StringSubscriber();
+        StringSubscriber s2 = new StringSubscriber();
+
+        registry.register(s1);
+        registry.register(s2);
+
+        registry.unregister(s1);
+        assertEquals(1, registry.getSubscribersForTesting(String.class).size());
+
+        registry.unregister(s2);
+        assertTrue(registry.getSubscribersForTesting(String.class).isEmpty());
+    }
+
+    @SuppressWarnings("EmptyCatchBlock")
+    @Test
+    public void testUnregister_notRegistered() {
+        try {
+            registry.unregister(new StringSubscriber());
+            fail();
+        } catch (IllegalArgumentException expected) {
+        }
+
+        StringSubscriber s1 = new StringSubscriber();
+        registry.register(s1);
+        try {
+            registry.unregister(new StringSubscriber());
+            fail();
+        } catch (IllegalArgumentException expected) {
+            // a StringSubscriber was registered, but not the same one we tried to unregister
+        }
+
+        registry.unregister(s1);
+
+        try {
+            registry.unregister(s1);
+            fail();
+        } catch (IllegalArgumentException expected) {
+        }
+    }
+
+    @Test
+    public void testGetSubscribers() {
+        assertEquals(0, Iterators.size(registry.getSubscribers("")));
+
+        registry.register(new StringSubscriber());
+        assertEquals(1, Iterators.size(registry.getSubscribers("")));
+
+        registry.register(new StringSubscriber());
+        assertEquals(2, Iterators.size(registry.getSubscribers("")));
+
+        registry.register(new ObjectSubscriber());
+        assertEquals(3, Iterators.size(registry.getSubscribers("")));
+        assertEquals(1, Iterators.size(registry.getSubscribers(new Object())));
+        assertEquals(1, Iterators.size(registry.getSubscribers(1)));
+
+        registry.register(new IntegerSubscriber());
+        assertEquals(3, Iterators.size(registry.getSubscribers("")));
+        assertEquals(1, Iterators.size(registry.getSubscribers(new Object())));
+        assertEquals(2, Iterators.size(registry.getSubscribers(1)));
+    }
+
+    @Test
+    public void testGetSubscribers_returnsImmutableSnapshot() {
+        StringSubscriber s1 = new StringSubscriber();
+        StringSubscriber s2 = new StringSubscriber();
+        ObjectSubscriber o1 = new ObjectSubscriber();
+
+        Iterator<FilterSubscriber> empty = registry.getSubscribers("");
+        assertFalse(empty.hasNext());
+
+        empty = registry.getSubscribers("");
+
+        registry.register(s1);
+        assertFalse(empty.hasNext());
+
+        Iterator<FilterSubscriber> one = registry.getSubscribers("");
+        assertEquals(s1, one.next().target);
+        assertFalse(one.hasNext());
+
+        one = registry.getSubscribers("");
+
+        registry.register(s2);
+        registry.register(o1);
+
+        Iterator<FilterSubscriber> three = registry.getSubscribers("");
+        assertEquals(s1, one.next().target);
+        assertFalse(one.hasNext());
+
+        assertEquals(s1, three.next().target);
+        assertEquals(s2, three.next().target);
+        assertEquals(o1, three.next().target);
+        assertFalse(three.hasNext());
+
+        three = registry.getSubscribers("");
+
+        registry.unregister(s2);
+
+        assertEquals(s1, three.next().target);
+        assertEquals(s2, three.next().target);
+        assertEquals(o1, three.next().target);
+        assertFalse(three.hasNext());
+
+        Iterator<FilterSubscriber> two = registry.getSubscribers("");
+        assertEquals(s1, two.next().target);
+        assertEquals(o1, two.next().target);
+        assertFalse(two.hasNext());
+    }
+
+    @Test
+    public void test_register_priority()
+    {
+        StringSubscriber s1 = new StringSubscriber();
+        StringSubscriber s2 = new StringSubscriber();
+        StringSubscriber s3 = new StringSubscriber();
+
+        assertEquals(0, registry.getSubscribersForTesting(String.class).size());
+
+        registry.register(s1, 80);
+        registry.register(s2, 30);
+        registry.register(s3, 10);
+
+        List<FilterSubscriber> subscribers = registry.getSubscribersForTesting(String.class);
+        assertEquals(3, subscribers.size());
+        assertThat(subscribers.get(0).target, equalTo(s3));
+        assertThat(subscribers.get(1).target, equalTo(s2));
+        assertThat(subscribers.get(2).target, equalTo(s1));
+    }
+
+    public static class InvalidSubscriber {
+        @SuppressWarnings("unused")
+        @Filter
+        public void handle(String s) {
+        }
+    }
+
+    public static class StringSubscriber {
+
+        @Filter
+        @SuppressWarnings("unused")
+        public String handle(String s) {
+            return s;
+        }
+    }
+
+    public static class IntegerSubscriber {
+
+        @Filter
+        @SuppressWarnings("unused")
+        public Integer handle(Integer i) {
+            return i;
+        }
+    }
+
+    public static class ObjectSubscriber {
+
+        @Filter
+        @SuppressWarnings("unused")
+        public Object handle(Object o) {
+            return o;
+        }
+    }
+
+    @Test
+    public void testFlattenHierarchy() {
+        assertEquals(
+                ImmutableSet.of(
+                        Object.class,
+                        HierarchyFixtureInterface.class,
+                        HierarchyFixtureSubinterface.class,
+                        HierarchyFixtureParent.class,
+                        HierarchyFixture.class),
+                FilterRegistry.flattenHierarchy(HierarchyFixture.class));
+    }
+
+    private interface HierarchyFixtureInterface {
+        // Exists only for hierarchy mapping; no members.
+    }
+
+    private interface HierarchyFixtureSubinterface
+            extends HierarchyFixtureInterface {
+        // Exists only for hierarchy mapping; no members.
+    }
+
+    private static class HierarchyFixtureParent
+            implements HierarchyFixtureSubinterface {
+        // Exists only for hierarchy mapping; no members.
+    }
+
+    private static class HierarchyFixture extends HierarchyFixtureParent {
+        // Exists only for hierarchy mapping; no members.
+    }
+}

--- a/src/test/resources/config.conf
+++ b/src/test/resources/config.conf
@@ -1,0 +1,12 @@
+#Test comment
+key1: "value1"
+key2: "value2"
+object: {
+  #Another comment
+  key1: "value3"
+  key2: "value4"
+  inner_object: {
+    key1: "value5"
+    key2: "value6" #Inline comment
+  }
+}

--- a/src/test/resources/config.json
+++ b/src/test/resources/config.json
@@ -1,0 +1,14 @@
+{
+  "key1": "value1",
+  "key2": "value2",
+  "object":
+  {
+    "key1": "value3",
+    "key2": "value4",
+    "inner_object":
+    {
+      "key1": "value5",
+      "key2": "value6"
+    }
+  }
+}

--- a/src/test/resources/config.properties
+++ b/src/test/resources/config.properties
@@ -1,0 +1,6 @@
+key1=value1
+key2=value2
+object.key1=value3
+object.key2=value4
+object.inner_object.key1=value5
+object.inner_object.key2=value6


### PR DESCRIPTION
Renamed the 'kairosdb.queue_processor' property to 'kairosdb.queue_processor.class' to match the new hierarchical property structure. This was necessary because there are other property names that begin with 'kairosdb.queue_processor' prompting the parser to treat this string as a reference to a collection of properties rather than to an individual property value.