### PR TITLE
Feature/forward prefix list

### DIFF
--- a/src/main/java/org/kairosdb/datastore/remote/RemoteDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/remote/RemoteDatastore.java
@@ -90,9 +90,6 @@ public class RemoteDatastore implements Datastore
 	@Named(METRIC_PREFIX_FILTER)
 	private String m_prefixFilter = null;
 
-	private String[] m_prefixFilterArr = null;
-
-
 	@Inject
 	private LongDataPointFactory m_longDataPointFactory = new LongDataPointFactoryImpl();
 
@@ -292,10 +289,10 @@ public class RemoteDatastore implements Datastore
 		if (m_prefixFilter != null)
 		{
 			m_prefixFilter = m_prefixFilter.replaceAll("\\s+","");
-			m_prefixFilterArr = m_prefixFilter.split(",");
+			String[] prefixFilterArr = m_prefixFilter.split(",");
 
 			boolean prefixMatch = false;
-			for (String prefixFilter : m_prefixFilterArr)
+			for (String prefixFilter : prefixFilterArr)
 			{
 				if (metricName.startsWith(prefixFilter))
 				{

--- a/src/main/java/org/kairosdb/datastore/remote/RemoteDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/remote/RemoteDatastore.java
@@ -90,6 +90,8 @@ public class RemoteDatastore implements Datastore
 	@Named(METRIC_PREFIX_FILTER)
 	private String m_prefixFilter = null;
 
+	private String[] m_prefixFilterArray;
+
 	@Inject
 	private LongDataPointFactory m_longDataPointFactory = new LongDataPointFactoryImpl();
 
@@ -101,6 +103,11 @@ public class RemoteDatastore implements Datastore
 		m_dataDirectory = dataDir;
 		m_remoteUrl = remoteUrl;
 		m_client = HttpClients.createDefault();
+		if (m_prefixFilter != null)
+		{
+			m_prefixFilter = m_prefixFilter.replaceAll("\\s+","");
+			m_prefixFilterArray = m_prefixFilter.split(",");
+		}
 
 		createNewMap();
 
@@ -288,11 +295,8 @@ public class RemoteDatastore implements Datastore
 
 		if (m_prefixFilter != null)
 		{
-			m_prefixFilter = m_prefixFilter.replaceAll("\\s+","");
-			String[] prefixFilterArr = m_prefixFilter.split(",");
-
 			boolean prefixMatch = false;
-			for (String prefixFilter : prefixFilterArr)
+			for (String prefixFilter : m_prefixFilterArray)
 			{
 				if (metricName.startsWith(prefixFilter))
 				{

--- a/src/main/java/org/kairosdb/datastore/remote/RemoteDatastore.java
+++ b/src/main/java/org/kairosdb/datastore/remote/RemoteDatastore.java
@@ -103,10 +103,13 @@ public class RemoteDatastore implements Datastore
 		m_dataDirectory = dataDir;
 		m_remoteUrl = remoteUrl;
 		m_client = HttpClients.createDefault();
+
+		logger.info("kairosdb.datastore.remote.prefix_filter:" + m_prefixFilter);
 		if (m_prefixFilter != null)
 		{
 			m_prefixFilter = m_prefixFilter.replaceAll("\\s+","");
 			m_prefixFilterArray = m_prefixFilter.split(",");
+			logger.info("Forwarding these prefixes to remote KairosDB:" + m_prefixFilterArray);
 		}
 
 		createNewMap();

--- a/src/main/resources/kairosdb.properties
+++ b/src/main/resources/kairosdb.properties
@@ -134,8 +134,8 @@ kairosdb.datastore.remote.schedule=0 */30 * * * ?
 # delay up to 10 minutes.
 kairosdb.datastore.remote.random_delay=0
 
-# Optional prefix filter for remote module.  Only metrics that start with this
-# value are forwarded on.
+# Optional prefix filter for remote module. If present, only metrics that start with the
+# values in this comma-separated list are forwarded on.
 #kairosdb.datastore.remote.prefix_filter=
 
 #===============================================================================


### PR DESCRIPTION
This change lets kairosdb.datastore.remote.prefix_filter be set to a comma-separated list of metric prefixes to forward to a remote KairosDB instance instead of just one.

Changes are in RemoteDatastore.java. Comment wording for kairosdb.datastore.remote.prefix_filter changed in kairosdb.properties to state that it can be a list.