### PR TITLE
adding DC awareness to policy; using read consistency level in query …

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraClientImpl.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraClientImpl.java
@@ -6,6 +6,7 @@ import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.ExponentialReconnectionPolicy;
 import com.datastax.driver.core.policies.LoadBalancingPolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
@@ -50,7 +51,9 @@ public class CassandraClientImpl implements CassandraClient, KairosMetricReporte
 	{
 		//Passing shuffleReplicas = false so we can properly batch data to
 		//instances.
-		m_loadBalancingPolicy = new TokenAwarePolicy(DCAwareRoundRobinPolicy.builder().build(), false);
+		// When connecting to Cassandra notes in different datacenters, the local datacenter should be provided.
+		// Not doing this will select the datacenter from the first connected Cassandra node, which is not guaranteed to be the correct one.
+		m_loadBalancingPolicy = new TokenAwarePolicy((configuration.getLocalDatacenter() == null) ? new RoundRobinPolicy() : DCAwareRoundRobinPolicy.builder().withLocalDc(configuration.getLocalDatacenter()).build(), false);
 		final Cluster.Builder builder = new Cluster.Builder()
 				//.withProtocolVersion(ProtocolVersion.V3)
 				.withPoolingOptions(new PoolingOptions().setConnectionsPerHost(HostDistance.LOCAL,
@@ -64,6 +67,7 @@ public class CassandraClientImpl implements CassandraClient, KairosMetricReporte
 				.withLoadBalancingPolicy(m_loadBalancingPolicy)
 				.withCompression(ProtocolOptions.Compression.LZ4)
 				.withoutJMXReporting()
+				.withQueryOptions(new QueryOptions().setConsistencyLevel(configuration.getDataReadLevel()))
 				.withTimestampGenerator(new TimestampGenerator() //todo need to remove this and put it only on the datapoints call
 				{
 					@Override

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraConfiguration.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraConfiguration.java
@@ -40,6 +40,8 @@ public class CassandraConfiguration
 	public static final String REMOTE_MAX_REQ_PER_CONN = "kairosdb.datastore.cassandra.max_requests_per_connection.remote";
 
 	public static final String MAX_QUEUE_SIZE = "kairosdb.datastore.cassandra.max_queue_size";
+	
+	public static final String LOCAL_DATACENTER = "kairosdb.datastore.cassandra.local_datacenter";
 
 	@Inject
 	@Named(WRITE_CONSISTENCY_LEVEL)
@@ -122,6 +124,10 @@ public class CassandraConfiguration
 	@Inject
 	@Named(MAX_QUEUE_SIZE)
 	private int m_maxQueueSize = 500;
+	
+	@Inject(optional = true)
+	@Named(LOCAL_DATACENTER)
+	private String m_localDatacenter;
 
 	public CassandraConfiguration()
 	{
@@ -230,6 +236,11 @@ public class CassandraConfiguration
 	public int getMaxQueueSize()
 	{
 		return m_maxQueueSize;
+	}
+	
+	public String getLocalDatacenter()
+	{
+		return m_localDatacenter;
 	}
 
 	public int getQueryReaderThreads()

--- a/src/main/resources/kairosdb.properties
+++ b/src/main/resources/kairosdb.properties
@@ -101,6 +101,9 @@ kairosdb.datastore.cassandra.string_cache_size=50000
 kairosdb.datastore.cassandra.read_consistency_level=ONE
 kairosdb.datastore.cassandra.write_consistency_level=QUORUM
 
+# Set this if this kairosdb node connects to cassandra nodes in multiple datacenters.
+# Not setting this will select cassandra hosts using the RoundRobinPolicy, while setting this will use DCAwareRoundRobinPolicy.
+#kairosdb.datastore.cassandra.local_datacenter=
 
 kairosdb.datastore.cassandra.connections_per_host.local.core=5
 kairosdb.datastore.cassandra.connections_per_host.local.max=100


### PR DESCRIPTION
This change fixes 2 separate things. Abstract:
1. creation of loadbalancing policy considers whether to use dc awareness by the optionally provided _local_datacenter_ property; implicit (and error-prone!) determination of the local datacenter by the driver disabled
2. query options consistency level is set using the _read_consistency_level_ property

Further elaborations:
1. When connecting a K* instance to a C* Cluster, the local datacenter name is implicitely being determined by the driver. I'll start with a log of a starting K* which connects to a multi-dc setup (3 C* nodes in dc-1 and dc-2 each):
> [...]09:41:21.901 [main] INFO  [DCAwareRoundRobinPolicy.java:95] - Using data-center name 'dc-1' for DCAwareRoundRobinPolicy (if this is incorrect, please provide the correct datacenter name with DCAwareRoundRobinPolicy constructor)
09:41:21.904 [main] WARN  [DCAwareRoundRobinPolicy.java:109] - Some contact points don't match local data center. Local DC = dc-1. Non-conforming contact points: /127.0.0.2:9042 (dc-2),/127.0.0.4:9042 (dc-2),/127.0.0.6:9042 (dc-2)[...]

In the example the first C* node to successfully connect to was a node in dc-1, thus the selection of this dc as "local dc" for K*. In this setup the chances are 50-50 for this to be correct.
This pull request adds an optional property _local_datacenter_ so the datacenter name can actually be provided. Furthermore, ommitting this optional property selects a "dc unaware" round robin policy which should be the correct policy in a single dc setup or in a setup that does not need to explicit separation of datacenters.

2. Right now the query options always use LOCAL_ONE consistency. This is the default consistency level for query in the driver 3.3 [(link to javadoc)](https://docs.datastax.com/en/drivers/java/3.3/com/datastax/driver/core/QueryOptions.html):
**Additional info:** The driver version 2 did in fact use consistency level ONE [(link to javadoc)](https://docs.datastax.com/en/drivers/java/2.0/com/datastax/driver/core/QueryOptions.html)
The problem with always using LOCAL_ONE is connected to the first change (unable to provide the local dc): you cannot stop one dc completely without causing problems in the connected K* instances:
> 10:13:45.560 [Ingest worker-0] ERROR [BatchHandler.java:174] - Not enough replicas available for query at consistency LOCAL_ONE (1 required but only 0 alive)

Therefor I propose to use the _read_consistency_level_ property for setting the query options consistency level.