### PR TITLE
optionally force use of default ttl; optionally align datapoint_ttl with timestamp

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/BatchHandler.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/BatchHandler.java
@@ -101,11 +101,11 @@ public class BatchHandler extends RetryCallable
 			// check if datapoint ttl alignment should be used
 			if (m_allignDatapointTtl) {
 				// determine the datapoint's "age" comparing it's timestamp and now
-				int datapointAgeInMs = (int) (writeTime - dataPoint.getTimestamp());
-				logger.trace("datapointAgeInMs (milliseconds): {}", datapointAgeInMs);
+				int datapointAgeInSeconds = (int) ((writeTime - dataPoint.getTimestamp()) / 1000);
+				logger.trace("datapointAgeInSeconds: {}", datapointAgeInSeconds);
 				
 				// the resulting aligned ttl is the former calculated ttl minus the datapoint's age
-				ttl = ttl - datapointAgeInMs / 1000;
+				ttl = ttl - datapointAgeInSeconds;
 				logger.trace("alligned ttl (seconds): {}", ttl);
 				// if the aligned ttl is negative, the datapoint is already dead
 				if (ttl <= 0) {

--- a/src/main/java/org/kairosdb/datastore/cassandra/BatchHandler.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/BatchHandler.java
@@ -93,6 +93,10 @@ public class BatchHandler extends RetryCallable
 			DataPointsRowKey rowKey = null;
 			//time the data is written.
 			long writeTime = System.currentTimeMillis();
+			
+			// set ttl to default if the event's ttl is not present or 0 (which actually can be 0 as well)
+			if (0 == ttl)
+				ttl = m_defaultTtl;
 
 			// check if datapoint ttl alignment should be used
 			if (m_allignDatapointTtl) {
@@ -111,7 +115,7 @@ public class BatchHandler extends RetryCallable
 			}
 			
 			//Row key will expire 3 weeks after the data in the row expires
-			int rowKeyTtl = ttl + ((int) (ROW_WIDTH / 1000));
+			int rowKeyTtl = (ttl == 0) ? 0 : ttl + ((int) (ROW_WIDTH / 1000));
 
 			long rowTime = calculateRowTime(dataPoint.getTimestamp());
 

--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraConfiguration.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraConfiguration.java
@@ -16,6 +16,9 @@ public class CassandraConfiguration
 	public static final String READ_CONSISTENCY_LEVEL = "kairosdb.datastore.cassandra.read_consistency_level";
 	public static final String WRITE_CONSISTENCY_LEVEL = "kairosdb.datastore.cassandra.write_consistency_level";
 	public static final String DATAPOINT_TTL = "kairosdb.datastore.cassandra.datapoint_ttl";
+	
+	public static final String ALIGN_DATAPOINT_TTL_WITH_TIMESTAMP = "kairosdb.datastore.cassandra.align_datapoint_ttl_with_timestamp";
+	public static final String FORCE_DEFAULT_DATAPOINT_TTL = "kairosdb.datastore.cassandra.force_default_datapoint_ttl";
 
 	public static final String ROW_KEY_CACHE_SIZE_PROPERTY = "kairosdb.datastore.cassandra.row_key_cache_size";
 	public static final String STRING_CACHE_SIZE_PROPERTY = "kairosdb.datastore.cassandra.string_cache_size";
@@ -52,6 +55,14 @@ public class CassandraConfiguration
 	@Inject(optional = true)
 	@Named(DATAPOINT_TTL)
 	private int m_datapointTtl = 0; //Zero ttl means data lives forever.
+
+	@Inject(optional = true)
+	@Named(ALIGN_DATAPOINT_TTL_WITH_TIMESTAMP)
+	private boolean m_alignDatapointTtlWithTimestamp = false;
+	
+	@Inject(optional = true)
+	@Named(FORCE_DEFAULT_DATAPOINT_TTL)
+	private boolean m_forceDefaultDatapointTtl = false;
 
 	@Inject
 	@Named(ROW_KEY_CACHE_SIZE_PROPERTY)
@@ -160,6 +171,16 @@ public class CassandraConfiguration
 	public int getDatapointTtl()
 	{
 		return m_datapointTtl;
+	}
+	
+	public boolean isAlignDatapointTtlWithTimestamp() 
+	{
+		return m_alignDatapointTtlWithTimestamp;
+	}
+	
+	public boolean isForceDefaultDatapointTtl()
+	{
+		return m_forceDefaultDatapointTtl;
 	}
 
 	public int getRowKeyCacheSize()

--- a/src/main/resources/kairosdb.properties
+++ b/src/main/resources/kairosdb.properties
@@ -130,6 +130,20 @@ kairosdb.datastore.cassandra.use_ssl=false
 #existing data, only new data.
 #kairosdb.datastore.cassandra.datapoint_ttl=31536000
 
+# Set this property to true to align each datapoint ttl with its timestamp.
+# example: datapoint_ttl is set to 30 days; ingesting a datapoint with timestamp '25 days ago'
+#   - Without this setting, the datapoint will be stored for 30 days from now on, so it can be queried for 30 + 25 days which may not be the intended behaviour using a 30 days ttl
+#   - Setting this property to true will only store this datapoint for 5 days (30 - 25 days).
+# default: false
+# Additional note: consider setting force_default_datapoint_ttl as well for full control
+kairosdb.datastore.cassandra.align_datapoint_ttl_with_timestamp=false
+
+# Set this property to true to force the default datapoint_ttl for all ingested datapoints, effectively ignoring their ttl informations if they provide them.
+# This gives you full control over the timespan the datapoints are stored in K*.
+# default: false
+# Additional note: consider setting align_datapoint_ttl_with_timestamp as well for full control
+kairosdb.datastore.cassandra.force_default_datapoint_ttl=false
+
 #===============================================================================
 # Remote datastore properties
 # Load the RemoteListener modules instead of RemoteDatastore if you want to


### PR DESCRIPTION
This pull request proposes the abilities to:
1. force the use of the default ttl, effectively ignoring any ttl information that is beeing provided by the senders. We're using TWCS as C* compaction strategy because we believe it fits best in combination with K* and the kind of data (flow of time series). And this in turn works best when the datapoint's ttl's are _regulated_, which means a (mostly) continuous flow of metrics. If every sender can provide their own ttl's, it's a lot harder to keep this infrastructure running, especially regarding the sstable growth is unpredictable.
**Short example**: using this option, senders are not able to store a datapoint for 10 years if the default (and thus company-wide) ttl is 1 year.
2. align the ttl of datapoints with their timestamps, thus datapoints are stored only for the expected ttl That means: take the datapoint's _age_ into consideration and compute the ttl with this information.
**Short example**: with a default ttl of 1 year, an inserted datapoint which is 9 months old at the time of ingestion (according to its timestamp) will have a ttl of 3 months.

Please take a look at the comments I added to the properties in the `kairosdb.properties`, too.