### PR TITLE
change system.out to logger

### DIFF
--- a/src/main/java/org/kairosdb/util/RetryCallable.java
+++ b/src/main/java/org/kairosdb/util/RetryCallable.java
@@ -2,8 +2,12 @@ package org.kairosdb.util;
 
 import java.util.concurrent.Callable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public abstract class RetryCallable implements Callable<Integer>
 {
+	public static final Logger logger = LoggerFactory.getLogger(RetryCallable.class);
 	private int m_retries = -1;
 
 	@Override
@@ -12,7 +16,7 @@ public abstract class RetryCallable implements Callable<Integer>
 		m_retries ++;
 
 		if (m_retries > 0)
-			System.out.println("Retrying batch");
+			logger.info("Retrying batch");
 
 		retryCall();
 


### PR DESCRIPTION
Simple change to a real logger for this message. Having this log entry between usually formatted log lines is quite irritating.
There's a system.out in the DemoModule as well, but that is only used in a really special case. :)