### PR TITLE
auth property corrected in kairosdb.properties file

### DIFF
--- a/src/main/resources/kairosdb.properties
+++ b/src/main/resources/kairosdb.properties
@@ -119,7 +119,7 @@ kairosdb.datastore.cassandra.max_queue_size=500
 #for cassandra authentication use the following
 #kairosdb.datastore.cassandra.auth.[prop name]=[prop value]
 #example:
-#kairosdb.datastore.cassandra.auth.username=admin
+#kairosdb.datastore.cassandra.auth.user_name=admin
 #kairosdb.datastore.cassandra.auth.password=eat_me
 
 # Set this property to true to enable SSL connections to your C* cluster.


### PR DESCRIPTION
This one is a potential time-killer in finding the reason why the hell authentication is not working properly. ;)

The correct property key regarding to the CassandraConfig.java is `AUTH_USER_NAME = "kairosdb.datastore.cassandra.auth.user_name"`