### PR TITLE
Fixed DoubleDataPoint equals and hashCode implementation

### DIFF
--- a/src/main/java/org/kairosdb/core/datapoints/DoubleDataPoint.java
+++ b/src/main/java/org/kairosdb/core/datapoints/DoubleDataPoint.java
@@ -6,7 +6,6 @@ import org.json.JSONWriter;
 
 import java.io.DataOutput;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 /**
  Created with IntelliJ IDEA.
@@ -88,6 +87,7 @@ public class DoubleDataPoint extends DataPointHelper
 	{
 		if (this == o) return true;
 		if (o == null || getClass() != o.getClass()) return false;
+		if (!super.equals(o)) return false;
 
 		DoubleDataPoint that = (DoubleDataPoint) o;
 
@@ -99,7 +99,9 @@ public class DoubleDataPoint extends DataPointHelper
 	@Override
 	public int hashCode()
 	{
+		int result = super.hashCode();
 		long temp = Double.doubleToLongBits(m_value);
-		return (int) (temp ^ (temp >>> 32));
+		result = 31 * result + (int) (temp ^ (temp >>> 32));
+		return result;
 	}
 }

--- a/src/test/java/org/kairosdb/core/datapoints/DataPointTestCommon.java
+++ b/src/test/java/org/kairosdb/core/datapoints/DataPointTestCommon.java
@@ -5,6 +5,7 @@ import org.kairosdb.core.DataPoint;
 
 import java.io.*;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -48,5 +49,12 @@ public class DataPointTestCommon
 		}
 
 		assertEquals(sum, testSum, 0.0001);
+	}
+
+	@Test
+	public void testEqualsHashCode() {
+		final HashSet<DataPoint> dataPointsSet = new HashSet<>(dataPointList);
+
+		assertEquals(dataPointList.size(), dataPointsSet.size());
 	}
 }

--- a/src/test/java/org/kairosdb/core/datapoints/DoubleDataPointTest.java
+++ b/src/test/java/org/kairosdb/core/datapoints/DoubleDataPointTest.java
@@ -20,7 +20,9 @@ public class DoubleDataPointTest extends DataPointTestCommon
 		dataPointList.clear();
 		dataPointList.add(doubleFactory.createDataPoint(123, 123.0));
 		dataPointList.add(doubleFactory.createDataPoint(1, 12345.67890));
+		dataPointList.add(doubleFactory.createDataPoint(1, 1.0));
+		dataPointList.add(doubleFactory.createDataPoint(123, 1.0));
 
-		sum = 12468.6789;
+		sum = 12470.6789;
 	}
 }

--- a/src/test/java/org/kairosdb/core/datapoints/LongDataPointTest.java
+++ b/src/test/java/org/kairosdb/core/datapoints/LongDataPointTest.java
@@ -1,6 +1,5 @@
 package org.kairosdb.core.datapoints;
 
-import org.junit.Before;
 import org.junit.BeforeClass;
 
 /**
@@ -20,12 +19,14 @@ public class LongDataPointTest extends DataPointTestCommon
 
 		dataPointList.clear();
 		dataPointList.add(longFactory.createDataPoint(1, 1));
+		dataPointList.add(longFactory.createDataPoint(1, 123));
+		dataPointList.add(longFactory.createDataPoint(123, 1));
 		dataPointList.add(longFactory.createDataPoint(123, 123));
 		dataPointList.add(longFactory.createDataPoint(1234, 1234));
 		dataPointList.add(longFactory.createDataPoint(65537, 65537));
 		dataPointList.add(longFactory.createDataPoint(4294967296L, 4294967296L));
 		dataPointList.add(longFactory.createDataPoint(1234567890L, 1234567890L));
 
-		sum = 5529602081.0;
+		sum = 5529602205.0;
 	}
 }


### PR DESCRIPTION
There's a difference in `equals` and `hashCode` implementations for `DoubleDataPoint` and `LongDataPoint`: the former uses only value for equality, the latter uses both value and timestamp (more specifically `LongDataPoint` call superclass methods which check timestamp). It's a small yet very crucial bug, which breaks least surprise principle.