### PR TITLE
Fix issue with sampling elements not showing for the percentile aggregator.

### DIFF
--- a/webroot/js/graph.js
+++ b/webroot/js/graph.js
@@ -660,6 +660,7 @@ function addAggregator(container) {
 		else if (name == "percentile") {
 			$aggregatorContainer.find(".aggregatorPercentile").show().css('display', 'table-cell');
 			$aggregatorContainer.find(".aggregatorSamplingUnit").show();
+			$aggregatorContainer.find(".aggregatorSampling").show();
 			$aggregatorContainer.find(".aggregatorAlign").show();
 		}
 		else if (name == "div") {


### PR DESCRIPTION
Currently the sampling UI elements don't show up for the percentile aggregator.  This is because the aggregatorSampling div is hidden and not shown when the aggregator is selected.  This diff causes the div to be shown when selecting the aggregator.