### PR TITLE
Added endpoint to run saved queries using search-and-replace parameterization

### DIFF
--- a/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
+++ b/src/main/java/org/kairosdb/core/http/rest/MetricsResource.java
@@ -540,8 +540,7 @@ public class MetricsResource implements KairosMetricReporter
 		try
 		{
 			ServiceKeyValue value = keyStore.getValue(service, serviceKey, queryName);
-			Optional<String> maybeJson = Optional.ofNullable(value)
-												.map(ServiceKeyValue::getValue);
+			Optional<String> maybeJson = Optional.ofNullable(value).map(ServiceKeyValue::getValue);
 
 			if (!maybeJson.isPresent())
 			{
@@ -551,9 +550,8 @@ public class MetricsResource implements KairosMetricReporter
 			}
 
 			String json = maybeJson.get();
-//			MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
-
-//			json = parameterizeQuery(json, queryParams);
+			MultivaluedMap<String, String> queryParams = uriInfo.getQueryParameters();
+			json = queryParser.parameterizeQuery(json, queryParams);
 
 			return runQuery(json, request.getRemoteAddr());
 		}

--- a/src/main/java/org/kairosdb/util/Util.java
+++ b/src/main/java/org/kairosdb/util/Util.java
@@ -17,6 +17,7 @@ package org.kairosdb.util;
 
 
 import com.google.common.collect.ImmutableList;
+import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.kairosdb.core.aggregator.Sampling;
@@ -34,8 +35,11 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.UnaryOperator;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static java.util.stream.Collectors.toMap;
 
 public class Util
 {
@@ -330,5 +334,28 @@ public class Util
 				break;
 		}
 		return ret;
+	}
+
+	public static String replaceEach(String text, Map<String, String> replacementMap)
+	{
+		String[] keys = new String[replacementMap.size()];
+		String[] values = new String[replacementMap.size()];
+		int i = 0;
+		for (Map.Entry<String, String> entry : replacementMap.entrySet())
+		{
+			keys[i] = entry.getKey();
+			values[i] = entry.getValue();
+			i++;
+		}
+		return StringUtils.replaceEach(text, keys, values);
+	}
+
+	public static <K,V> Map<K,V> transformMap(Map<K,V> map, UnaryOperator<K> keyMapper, UnaryOperator<V> valueMapper)
+	{
+		return map.entrySet().stream()
+				.collect(toMap(
+						entry -> keyMapper.apply(entry.getKey()),
+						entry -> valueMapper.apply(entry.getValue())
+				));
 	}
 }

--- a/src/test/java/org/kairosdb/core/http/rest/MetricsResourceTest.java
+++ b/src/test/java/org/kairosdb/core/http/rest/MetricsResourceTest.java
@@ -162,9 +162,23 @@ public class MetricsResourceTest extends ResourceBase
 	public void testGetSavedQueryWithNoParameters() throws IOException, DatastoreException
 	{
 		String json = Resources.toString(Resources.getResource("query-metric-absolute-dates.json"), Charsets.UTF_8);
-		datastore.setValue("SavedQueries", "default", "query-metric-absolute-dates", json);
+		datastore.setValue("SavedQueries", "default", "query", json);
 
-		JsonResponse response = client.get(GET_SAVED_QUERY_URL + "/SavedQueries/default/query-metric-absolute-dates");
+		JsonResponse response = client.get(GET_SAVED_QUERY_URL + "/SavedQueries/default/query");
+
+		assertResponse(response, 200,
+				"{\"queries\":" +
+						"[{\"sample_size\":10,\"results\":" +
+						"[{\"name\":\"abc.123\",\"group_by\":[{\"name\":\"type\",\"type\":\"number\"}],\"tags\":{\"server\":[\"server1\",\"server2\"]},\"values\":[[1,60.2],[2,30.200000000000003],[3,20.1]]}]}]}");
+	}
+
+	@Test
+	public void testGetSavedQueryWithParameters() throws IOException, DatastoreException
+	{
+		String json = Resources.toString(Resources.getResource("query-metric-with-variable-absolute-dates.json"), Charsets.UTF_8);
+		datastore.setValue("SavedQueries", "default", "query", json);
+
+		JsonResponse response = client.get(GET_SAVED_QUERY_URL + "/SavedQueries/default/query?start_absolute=784041330&end_absolute=788879730");
 
 		assertResponse(response, 200,
 				"{\"queries\":" +
@@ -186,9 +200,9 @@ public class MetricsResourceTest extends ResourceBase
 	public void testGetSavedQueryWithBeanValidationException() throws IOException, DatastoreException
 	{
 		String json = Resources.toString(Resources.getResource("invalid-query-metric-relative-unit.json"), Charsets.UTF_8);
-		datastore.setValue("SavedQueries", "default", "invalid-query-metric-relative-unit", json);
+		datastore.setValue("SavedQueries", "default", "query", json);
 
-		JsonResponse response = client.get(GET_SAVED_QUERY_URL + "/SavedQueries/default/invalid-query-metric-relative-unit");
+		JsonResponse response = client.get(GET_SAVED_QUERY_URL + "/SavedQueries/default/query");
 
 		assertResponse(response, 400,
 				"{\"errors\":[\"query.bogus is not a valid time unit, must be one of MILLISECONDS,SECONDS,MINUTES,HOURS,DAYS,WEEKS,MONTHS,YEARS\"]}");
@@ -198,9 +212,9 @@ public class MetricsResourceTest extends ResourceBase
 	public void testGetSavedQueryWithJsonMapperParsingException() throws IOException, DatastoreException
 	{
 		String json = Resources.toString(Resources.getResource("invalid-query-metric-json.json"), Charsets.UTF_8);
-		datastore.setValue("SavedQueries", "default", "invalid-query-metric-json", json);
+		datastore.setValue("SavedQueries", "default", "query", json);
 
-		JsonResponse response = client.get(GET_SAVED_QUERY_URL + "/SavedQueries/default/invalid-query-metric-json");
+		JsonResponse response = client.get(GET_SAVED_QUERY_URL + "/SavedQueries/default/query");
 
 		assertResponse(response, 400,
 				"{\"errors\":[\"com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 2 column 22\"]}");
@@ -332,7 +346,7 @@ public class MetricsResourceTest extends ResourceBase
 	{
 		resource.setServerType("INGEST");
 
-		JsonResponse response = client.get(GET_SAVED_QUERY_URL + "/SavedQueries/default/query1");
+		JsonResponse response = client.get(GET_SAVED_QUERY_URL + "/SavedQueries/default/query");
 
 		assertResponse(response, 403, "[{\"Forbidden\": \"QUERY API methods are disabled on this KairosDB instance.\"}]\n");
 

--- a/src/test/java/org/kairosdb/core/http/rest/ResourceBase.java
+++ b/src/test/java/org/kairosdb/core/http/rest/ResourceBase.java
@@ -138,12 +138,13 @@ public abstract class ResourceBase
             server.stop();
         }
     }
-//
-//    @After
-//    public void tearDown()
-//    {
-//        datastore.throwException(null);
-//    }
+
+    @After
+    public void tearDown()
+    {
+        datastore.throwException(null);
+        datastore.clear();
+    }
 
     public static class TestDatastore implements Datastore, ServiceKeyStore
     {
@@ -303,6 +304,11 @@ public abstract class ResourceBase
                 throw m_toThrow;
 
             metadata.remove(service + "/" + serviceKey + "/" + key);
+        }
+
+        public void clear()
+        {
+            metadata = new TreeMap<>();
         }
 
         @Override

--- a/src/test/java/org/kairosdb/core/http/rest/ResourceBase.java
+++ b/src/test/java/org/kairosdb/core/http/rest/ResourceBase.java
@@ -7,6 +7,7 @@ import com.google.inject.name.Names;
 import com.google.inject.spi.InjectionListener;
 import com.google.inject.spi.TypeEncounter;
 import com.google.inject.spi.TypeListener;
+import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.kairosdb.core.GuiceKairosDataPointFactory;
@@ -130,13 +131,19 @@ public abstract class ResourceBase
     }
 
     @AfterClass
-    public static void tearDown()
+    public static void shutdown() throws Exception
     {
         if (server != null)
         {
             server.stop();
         }
     }
+//
+//    @After
+//    public void tearDown()
+//    {
+//        datastore.throwException(null);
+//    }
 
     public static class TestDatastore implements Datastore, ServiceKeyStore
     {

--- a/src/test/java/org/kairosdb/util/UtilTest.java
+++ b/src/test/java/org/kairosdb/util/UtilTest.java
@@ -1,8 +1,13 @@
 package org.kairosdb.util;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 public class UtilTest
@@ -89,5 +94,46 @@ public class UtilTest
 	public void test_isNumber_withMinusSign()
 	{
 		assertThat(Util.isNumber("-102"), equalTo(true));
+	}
+
+	@Test
+	public void test_replaceEach_emptyString()
+	{
+		assertEquals("", Util.replaceEach("", ImmutableMap.of("foo", "*")));
+	}
+
+	@Test
+	public void test_replaceEach_emptyMap()
+	{
+		String text = "foo bar";
+		assertEquals(text, Util.replaceEach(text, new HashMap<>()));
+	}
+
+	@Test
+	public void test_replaceEach_searchValueNotInText()
+	{
+		String text = "foo bar";
+		assertEquals(text, Util.replaceEach(text, ImmutableMap.of("baz", "$")));
+	}
+
+	@Test
+	public void test_replaceEach_replaceSingleValue()
+	{
+		String text = "foo bar";
+		assertEquals("* bar", Util.replaceEach(text, ImmutableMap.of("foo", "*")));
+	}
+
+	@Test
+	public void test_replaceEach_replaceMultipleValues()
+	{
+		String text = "foo bar";
+		assertEquals("* #", Util.replaceEach(text, ImmutableMap.of("foo", "*", "bar", "#")));
+	}
+
+	@Test
+	public void test_replaceEach_replaceMultipleFoundInstances()
+	{
+		String text = "foo bar foo";
+		assertEquals("* bar *", Util.replaceEach(text, ImmutableMap.of("foo", "*")));
 	}
 }

--- a/src/test/resources/query-metric-timezone.json
+++ b/src/test/resources/query-metric-timezone.json
@@ -1,0 +1,24 @@
+{
+  "start_absolute": 784041330,
+  "end_absolute": 788879730,
+  "time_zone": "America/Denver",
+  "metrics": [
+    {
+      "name": "abc.123",
+      "aggregators":[
+        {
+          "name":"sum",
+          "sampling":
+          {
+            "value": 1,
+            "unit": "milliseconds"
+          }
+        }
+      ],
+      "tags": {
+        "host": "foo",
+        "type": "bar"
+      }
+    }
+  ]
+}

--- a/src/test/resources/query-metric-with-variable-absolute-dates.json
+++ b/src/test/resources/query-metric-with-variable-absolute-dates.json
@@ -1,0 +1,22 @@
+{
+  "start_absolute": "$start_absolute",
+  "end_absolute": "$end_absolute",
+  "metrics": [
+    {
+      "name": "abc.123",
+      "aggregators": [
+        {
+          "name": "sum",
+          "sampling": {
+            "value": 1,
+            "unit": "milliseconds"
+          }
+        }
+      ],
+      "tags": {
+        "host": "foo",
+        "type": "bar"
+      }
+    }
+  ]
+}

--- a/src/test/resources/query-metric-with-variable-host-tag.json
+++ b/src/test/resources/query-metric-with-variable-host-tag.json
@@ -1,0 +1,12 @@
+{
+  "start_absolute": 784041330,
+  "end_absolute": 788879730,
+  "metrics": [
+    {
+      "name": "bob",
+      "tags": {
+        "host": ["$metrics[0].tags.host"]
+      }
+    }
+  ]
+}

--- a/src/test/resources/query-metric-with-variable-timezone.json
+++ b/src/test/resources/query-metric-with-variable-timezone.json
@@ -1,0 +1,24 @@
+{
+  "start_absolute": 784041330,
+  "end_absolute": 788879730,
+  "time_zone": "$time_zone",
+  "metrics": [
+    {
+      "name": "abc.123",
+      "aggregators":[
+        {
+          "name":"sum",
+          "sampling":
+          {
+            "value": 1,
+            "unit": "milliseconds"
+          }
+        }
+      ],
+      "tags": {
+        "host": "foo",
+        "type": "bar"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Values in the saved query JSON that begin with a dollar sign will act as placeholders. On a call to the get saved query endpoint, these placholders will be replaced with the value of the matching parameter. For example, the string "$start_absolute" in the query JSON will be replaced with the value of the start_absolute parameter in the API call.