### PR TITLE
Remove USING TIMESTAMP clause from data points insert statement.

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/CQLBatch.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CQLBatch.java
@@ -145,7 +145,6 @@ public class CQLBatch
 		boundStatement.setBytesUnsafe(1, b);
 		boundStatement.setBytesUnsafe(2, ByteBuffer.wrap(kDataOutput.getBytes()));
 		boundStatement.setInt(3, ttl);
-		boundStatement.setLong(4, m_now);
 		boundStatement.setConsistencyLevel(m_consistencyLevel);
 		boundStatement.setIdempotent(true);
 

--- a/src/main/java/org/kairosdb/datastore/cassandra/ClusterConnection.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/ClusterConnection.java
@@ -101,7 +101,7 @@ public class ClusterConnection
 
 	//All inserts and deletes add millisecond timestamp consistency with old code and TWCS instead of nanos
 	public static final String DATA_POINTS_INSERT = "INSERT INTO data_points " +
-			"(key, column1, value) VALUES (?, ?, ?) USING TTL ? AND TIMESTAMP ?";
+			"(key, column1, value) VALUES (?, ?, ?) USING TTL ?";
 
 	public static final String ROW_KEY_TIME_INSERT = "INSERT INTO row_key_time_index " +
 			"(metric, table_name, row_time) VALUES (?, 'data_points', ?) USING TTL ?";


### PR DESCRIPTION
YugaByte is strongly consistent, and update order is controlled by the RAFT replication sequence.
Therefore, when USING TIMESTAMP is used, YugaByte DB would incur a read penalty to make sure that
an insert with a lower timestamp does not actually take place which is unnecessary.

Under the covers, YugaByte DB implements user specified timestamps (i.e. the USING TIMESTAMP clause)
as an additional implicit column, which needs to be read on each insert.