### PR TITLE
Fix import and export bash

### DIFF
--- a/src/scripts/kairosdb.sh
+++ b/src/scripts/kairosdb.sh
@@ -57,10 +57,10 @@ elif [ "$1" = "stop" ] ; then
 	rm $KAIROS_PID_FILE
 elif [ "$1" = "export" ] ; then
 	shift
-	exec "$JAVA" $JAVA_OPTS -cp $CLASSPATH org.kairosdb.core.Main -c export -p conf/kairosdb.conf $*
+	exec "$JAVA" $JAVA_OPTS -cp $CLASSPATH org.kairosdb.core.Main -c export -p conf/kairosdb.conf "$@"
 elif [ "$1" = "import" ] ; then
 	shift
-	exec "$JAVA" $JAVA_OPTS -cp $CLASSPATH org.kairosdb.core.Main -c import -p conf/kairosdb.conf $*
+	exec "$JAVA" $JAVA_OPTS -cp $CLASSPATH org.kairosdb.core.Main -c import -p conf/kairosdb.conf "$@"
 else
 	echo "Unrecognized command."
 	exit 1


### PR DESCRIPTION
Fix import and export for metric names containing space. If a metric name contains spaces, it passes the metric name as two separate words and JCommander can't recognize it as one word even when we surround the metric name with quotas.