### PR TITLE
Add a config option to filter tags applied during indexing

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/CassandraModule.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/CassandraModule.java
@@ -31,8 +31,8 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.assistedinject.Assisted;
 import com.google.inject.assistedinject.FactoryModuleBuilder;
 import com.google.inject.name.Names;
-import org.kairosdb.core.KairosRootConfig;
 import org.kairosdb.core.DataPoint;
+import org.kairosdb.core.KairosRootConfig;
 import org.kairosdb.core.datastore.Datastore;
 import org.kairosdb.core.datastore.ServiceKeyStore;
 import org.kairosdb.core.exception.DatastoreException;
@@ -42,7 +42,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Named;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -144,14 +143,16 @@ public class CassandraModule extends AbstractModule
 		{
 			m_metaCluster = m_writeCluster = new ClusterConnection(writeClient, EnumSet.of(
 					ClusterConnection.Type.WRITE, ClusterConnection.Type.META),
-					writeConfig.getTagIndexedMetrics());
+					writeConfig.getTagIndexedMetrics(),
+					writeConfig.getTagIndexedMetricTagNames());
 			m_metaCluster.startup(configuration.isStartAsync());
 		}
 		else
 		{
 			m_writeCluster = new ClusterConnection(writeClient, EnumSet.of(
 					ClusterConnection.Type.WRITE),
-					writeConfig.getTagIndexedMetrics());
+					writeConfig.getTagIndexedMetrics(),
+					writeConfig.getTagIndexedMetricTagNames());
 			m_writeCluster.startup(configuration.isStartAsync());
 
 			Injector metaInjector = injector.createChildInjector((Module) binder -> bindCassandraClient(binder, metaConfig) );
@@ -159,7 +160,7 @@ public class CassandraModule extends AbstractModule
 			CassandraClient metaClient = metaInjector.getInstance(CassandraClient.class);
 
 			m_metaCluster = new ClusterConnection(metaClient, EnumSet.of(
-					ClusterConnection.Type.META), new HashSet<>());
+					ClusterConnection.Type.META), new HashSet<>(), new HashSet<>());
 			m_metaCluster.startup(configuration.isStartAsync());
 		}
 	}
@@ -216,7 +217,7 @@ public class CassandraModule extends AbstractModule
 				CassandraClient client = readInjector.getInstance(CassandraClient.class);
 
 				clusters.add(new ClusterConnection(client, EnumSet.of(ClusterConnection.Type.READ),
-						clusterConfiguration.getTagIndexedMetrics()).startup(configuration.isStartAsync()));
+						clusterConfiguration.getTagIndexedMetrics(), clusterConfiguration.getTagIndexedMetricTagNames()).startup(configuration.isStartAsync()));
 			}
 		}
 		catch (Exception e)

--- a/src/main/java/org/kairosdb/datastore/cassandra/ClusterConfiguration.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/ClusterConfiguration.java
@@ -37,6 +37,7 @@ public class ClusterConfiguration
 	private final Map<String, Integer> m_hostList;
 	private final String m_clusterName;
 	private final Set<String> m_tagIndexedMetrics;
+	private final Set<String> m_tagIndexedMetricTagNames;
 	private String m_authPassword;
 	private String m_authUser;
 	private String m_localDCName;
@@ -111,6 +112,7 @@ public class ClusterConfiguration
 		checkState(m_startTime < m_endTime, "Cluster start time must be before end time");
 
 		m_tagIndexedMetrics = new HashSet<>(config.getStringList("tag_indexed_row_key_lookup_metrics", new ArrayList<String>()));
+		m_tagIndexedMetricTagNames = new HashSet<>(config.getStringList("tag_indexed_row_tag_filter", new ArrayList<String>()));
 	}
 
 	public String getKeyspace()
@@ -221,6 +223,11 @@ public class ClusterConfiguration
 	public Set<String> getTagIndexedMetrics()
 	{
 		return m_tagIndexedMetrics;
+	}
+
+	public Set<String> getTagIndexedMetricTagNames()
+	{
+		return m_tagIndexedMetricTagNames;
 	}
 }
 

--- a/src/main/resources/kairosdb.conf
+++ b/src/main/resources/kairosdb.conf
@@ -178,6 +178,12 @@ kairosdb: {
 			# If you turn on the tag index lookup for that metric it will create 4 inserts,
 			# one for the data and one for each tag.
 			tag_indexed_row_key_lookup_metrics: []
+
+			# Set this property to a list of tag keys. Tag indexed metrics will only have tags with these keys indexed.
+			# Use this for high-cardinality tags where the majority of your queries filter by exactly these tags.
+			# Queries made without these exact tags will not perform well with the index.
+			# This works well if you have a UUID you always query with for the indexed metrics.
+			tag_indexed_row_tag_filter: []
 		}
 
 		# Rename this to read_clusters in order for it to be used

--- a/src/test/java/org/kairosdb/datastore/cassandra/CassandraDatastoreTest.java
+++ b/src/test/java/org/kairosdb/datastore/cassandra/CassandraDatastoreTest.java
@@ -295,7 +295,8 @@ public class CassandraDatastoreTest extends DatastoreTestHelper
 		client.init();
 		m_clusterConnection = new ClusterConnection(client,
 				EnumSet.of(ClusterConnection.Type.WRITE, ClusterConnection.Type.META),
-				new HashSet<>()).startup(false);
+				new HashSet<>(),
+				new HashSet<>()).startup(false);;
 		BatchStats batchStats = new BatchStats();
 		DataCache<DataPointsRowKey> rowKeyCache = new DataCache<>(1024);
 		DataCache<String> metricNameCache = new DataCache<>(1024);

--- a/src/test/java/org/kairosdb/datastore/cassandra/RowKeyLookupProviderTest.java
+++ b/src/test/java/org/kairosdb/datastore/cassandra/RowKeyLookupProviderTest.java
@@ -40,7 +40,7 @@ public class RowKeyLookupProviderTest
 	public void testWithWildcard()
 	{
 		ClusterConnection connection = new ClusterConnection(m_cassandraClient, m_clusterType,
-			Collections.singleton("*"));
+			Collections.singleton("*"), new HashSet<>());
 
 		RowKeyLookup rowKeyLookup = connection.getRowKeyLookupForMetric("someMetric");
 
@@ -51,7 +51,7 @@ public class RowKeyLookupProviderTest
 	public void testWithoutEmptyStringConfig()
 	{
 		ClusterConnection connection = new ClusterConnection(m_cassandraClient, m_clusterType,
-				Collections.singleton(""));
+				Collections.singleton(""), new HashSet<>());
 
 		RowKeyLookup rowKeyLookup = connection.getRowKeyLookupForMetric("someMetric");
 
@@ -62,6 +62,7 @@ public class RowKeyLookupProviderTest
 	public void testWithEmptySet()
 	{
 		ClusterConnection connection = new ClusterConnection(m_cassandraClient, m_clusterType,
+				new HashSet<>(),
 				new HashSet<>());
 
 		RowKeyLookup rowKeyLookup = connection.getRowKeyLookupForMetric("someMetric");
@@ -73,7 +74,7 @@ public class RowKeyLookupProviderTest
 	public void testWithMetricSetConfig()
 	{
 		ClusterConnection connection = new ClusterConnection(m_cassandraClient, m_clusterType,
-				ImmutableSet.of("metricA", "metricB"));
+				ImmutableSet.of("metricA", "metricB"), new HashSet<>());
 
 		RowKeyLookup rowKeyLookup = connection.getRowKeyLookupForMetric("someMetric");
 


### PR DESCRIPTION
I don't think this is 100% there, but I wanted to get it started. I've added a config to filter down indexed tags (we have a UUID which all queries use when querying).