### PR TITLE
Make first and last aggregator string compatible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: java
 
 jdk:
   - oraclejdk8
+dist: trusty
 
 #services:
 #  - cassandra
@@ -16,4 +17,4 @@ script:
 
 before_install:
   - sudo rm -rf /var/lib/cassandra/*
-  - wget http://www.us.apache.org/dist/cassandra/3.11.4/apache-cassandra-3.11.4-bin.tar.gz && tar -xvzf apache-cassandra-3.11.4-bin.tar.gz && sudo sh apache-cassandra-3.11.4/bin/cassandra -R
+  - wget http://www.us.apache.org/dist/cassandra/3.11.5/apache-cassandra-3.11.5-bin.tar.gz && tar -xvzf apache-cassandra-3.11.5-bin.tar.gz && sudo sh apache-cassandra-3.11.5/bin/cassandra -R

--- a/src/main/java/org/kairosdb/core/aggregator/FirstAggregator.java
+++ b/src/main/java/org/kairosdb/core/aggregator/FirstAggregator.java
@@ -32,12 +32,10 @@ import java.util.Iterator;
 )
 public class FirstAggregator extends RangeAggregator
 {
-	private DoubleDataPointFactory m_dataPointFactory;
 
 	@Inject
-	public FirstAggregator(DoubleDataPointFactory dataPointFactory)
+	public FirstAggregator()
 	{
-		m_dataPointFactory = dataPointFactory;
 	}
 
 	@Override
@@ -49,7 +47,7 @@ public class FirstAggregator extends RangeAggregator
 	@Override
 	public String getAggregatedGroupType(String groupType)
 	{
-		return m_dataPointFactory.getGroupType();
+		return groupType;
 	}
 
 	@Override

--- a/src/main/java/org/kairosdb/core/aggregator/LastAggregator.java
+++ b/src/main/java/org/kairosdb/core/aggregator/LastAggregator.java
@@ -32,12 +32,11 @@ import java.util.Iterator;
 )
 public class LastAggregator extends RangeAggregator
 {
-	private DoubleDataPointFactory m_dataPointFactory;
 
 	@Inject
-	public LastAggregator(DoubleDataPointFactory dataPointFactory)
+	public LastAggregator()
 	{
-		m_dataPointFactory = dataPointFactory;
+
 	}
 
 	@Override
@@ -49,7 +48,7 @@ public class LastAggregator extends RangeAggregator
 	@Override
 	public String getAggregatedGroupType(String groupType)
 	{
-		return m_dataPointFactory.getGroupType();
+		return groupType;
 	}
 
 	@Override

--- a/src/test/java/org/kairosdb/core/aggregator/FirstAggregatorTest.java
+++ b/src/test/java/org/kairosdb/core/aggregator/FirstAggregatorTest.java
@@ -19,9 +19,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kairosdb.core.DataPoint;
 import org.kairosdb.core.datapoints.DoubleDataPoint;
-import org.kairosdb.core.datapoints.DoubleDataPointFactoryImpl;
 import org.kairosdb.core.datapoints.LegacyLongDataPoint;
 import org.kairosdb.core.datapoints.LongDataPoint;
+import org.kairosdb.core.datapoints.StringDataPoint;
 import org.kairosdb.core.datastore.DataPointGroup;
 import org.kairosdb.testing.ListDataPointGroup;
 
@@ -35,7 +35,7 @@ public class FirstAggregatorTest
 	@Before
 	public void setup()
 	{
-		aggregator = new FirstAggregator(new DoubleDataPointFactoryImpl());
+		aggregator = new FirstAggregator();
 	}
 
 	@Test(expected = NullPointerException.class)
@@ -112,7 +112,9 @@ public class FirstAggregatorTest
 		group.addDataPoint(new LongDataPoint(2, 1));
 		group.addDataPoint(new DoubleDataPoint(2, 3.2));
 		group.addDataPoint(new DoubleDataPoint(2, 5.0));
+		group.addDataPoint(new StringDataPoint(3, "25.3"));
 		group.addDataPoint(new DoubleDataPoint(3, 25.1));
+		group.addDataPoint(new DoubleDataPoint(4, 23.4));
 
 		DataPointGroup results = aggregator.aggregate(group);
 
@@ -126,7 +128,11 @@ public class FirstAggregatorTest
 
 		dataPoint = results.next();
 		assertThat(dataPoint.getTimestamp(), equalTo(3L));
-		assertThat(dataPoint.getDoubleValue(), equalTo(25.1));
+		assertThat(((StringDataPoint)dataPoint).getValue(), equalTo("25.3"));
+
+		dataPoint = results.next();
+		assertThat(dataPoint.getTimestamp(), equalTo(4L));
+		assertThat(dataPoint.getDoubleValue(), equalTo(23.4));
 
 		assertThat(results.hasNext(), equalTo(false));
 	}
@@ -178,6 +184,35 @@ public class FirstAggregatorTest
 		DataPoint dataPoint = results.next();
 		assertThat(dataPoint.getTimestamp(), equalTo(1L));
 		assertThat(dataPoint.getLongValue(), equalTo(10L));
+
+		assertThat(results.hasNext(), equalTo(false));
+	}
+
+	@Test
+	public void test_stringValues()
+	{
+		ListDataPointGroup group = new ListDataPointGroup("group");
+		group.addDataPoint(new StringDataPoint(1, "a"));
+		group.addDataPoint(new StringDataPoint(1, "b"));
+		group.addDataPoint(new StringDataPoint(1, "c"));
+		group.addDataPoint(new StringDataPoint(2, "d"));
+		group.addDataPoint(new StringDataPoint(2, "e"));
+		group.addDataPoint(new StringDataPoint(2, "f"));
+		group.addDataPoint(new StringDataPoint(3, "g"));
+
+		DataPointGroup results = aggregator.aggregate(group);
+
+		DataPoint dataPoint = results.next();
+		assertThat(dataPoint.getTimestamp(), equalTo(1L));
+		assertThat(((StringDataPoint)dataPoint).getValue(), equalTo("a"));
+
+		dataPoint = results.next();
+		assertThat(dataPoint.getTimestamp(), equalTo(2L));
+		assertThat(((StringDataPoint)dataPoint).getValue(), equalTo("d"));
+
+		dataPoint = results.next();
+		assertThat(dataPoint.getTimestamp(), equalTo(3L));
+		assertThat(((StringDataPoint)dataPoint).getValue(), equalTo("g"));
 
 		assertThat(results.hasNext(), equalTo(false));
 	}

--- a/src/test/java/org/kairosdb/core/aggregator/LastAggregatorTest.java
+++ b/src/test/java/org/kairosdb/core/aggregator/LastAggregatorTest.java
@@ -19,9 +19,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kairosdb.core.DataPoint;
 import org.kairosdb.core.datapoints.DoubleDataPoint;
-import org.kairosdb.core.datapoints.DoubleDataPointFactoryImpl;
 import org.kairosdb.core.datapoints.LegacyLongDataPoint;
 import org.kairosdb.core.datapoints.LongDataPoint;
+import org.kairosdb.core.datapoints.StringDataPoint;
 import org.kairosdb.core.datastore.DataPointGroup;
 import org.kairosdb.core.datastore.TimeUnit;
 import org.kairosdb.testing.ListDataPointGroup;
@@ -36,7 +36,7 @@ public class LastAggregatorTest
 	@Before
 	public void setup()
 	{
-		aggregator = new LastAggregator(new DoubleDataPointFactoryImpl());
+		aggregator = new LastAggregator();
 	}
 
 	@Test(expected = NullPointerException.class)
@@ -114,6 +114,8 @@ public class LastAggregatorTest
 		group.addDataPoint(new DoubleDataPoint(2, 3.2));
 		group.addDataPoint(new DoubleDataPoint(2, 5.0));
 		group.addDataPoint(new DoubleDataPoint(3, 25.1));
+		group.addDataPoint(new StringDataPoint(3, "23.1"));
+		group.addDataPoint(new DoubleDataPoint(4, 25.1));
 
 		DataPointGroup results = aggregator.aggregate(group);
 
@@ -127,6 +129,10 @@ public class LastAggregatorTest
 
 		dataPoint = results.next();
 		assertThat(dataPoint.getTimestamp(), equalTo(3L));
+		assertThat(((StringDataPoint)dataPoint).getValue(), equalTo("23.1"));
+
+		dataPoint = results.next();
+		assertThat(dataPoint.getTimestamp(), equalTo(4L));
 		assertThat(dataPoint.getDoubleValue(), equalTo(25.1));
 
 		assertThat(results.hasNext(), equalTo(false));
@@ -184,6 +190,35 @@ public class LastAggregatorTest
 	}
 
 	@Test
+	public void test_stringValues()
+	{
+		ListDataPointGroup group = new ListDataPointGroup("group");
+		group.addDataPoint(new StringDataPoint(1, "a"));
+		group.addDataPoint(new StringDataPoint(1, "b"));
+		group.addDataPoint(new StringDataPoint(1, "c"));
+		group.addDataPoint(new StringDataPoint(2, "d"));
+		group.addDataPoint(new StringDataPoint(2, "e"));
+		group.addDataPoint(new StringDataPoint(2, "f"));
+		group.addDataPoint(new StringDataPoint(3, "g"));
+
+		DataPointGroup results = aggregator.aggregate(group);
+
+		DataPoint dataPoint = results.next();
+		assertThat(dataPoint.getTimestamp(), equalTo(1L));
+		assertThat(((StringDataPoint)dataPoint).getValue(), equalTo("c"));
+
+		dataPoint = results.next();
+		assertThat(dataPoint.getTimestamp(), equalTo(2L));
+		assertThat(((StringDataPoint)dataPoint).getValue(), equalTo("f"));
+
+		dataPoint = results.next();
+		assertThat(dataPoint.getTimestamp(), equalTo(3L));
+		assertThat(((StringDataPoint)dataPoint).getValue(), equalTo("g"));
+
+		assertThat(results.hasNext(), equalTo(false));
+	}
+
+	@Test
 	public void test_alignStartOn()
 	{
 		ListDataPointGroup group = new ListDataPointGroup("group");
@@ -196,7 +231,7 @@ public class LastAggregatorTest
 		group.addDataPoint(new LongDataPoint(7, 5));
 		group.addDataPoint(new LongDataPoint(8, 25));
 
-		LastAggregator lastAggregator = new LastAggregator(new DoubleDataPointFactoryImpl());
+		LastAggregator lastAggregator = new LastAggregator();
 		lastAggregator.setSampling(new Sampling(5, TimeUnit.MILLISECONDS));
 		lastAggregator.setAlignStartTime(true);
 		DataPointGroup results = lastAggregator.aggregate(group);
@@ -225,7 +260,7 @@ public class LastAggregatorTest
 		group.addDataPoint(new LongDataPoint(7, 5));
 		group.addDataPoint(new LongDataPoint(8, 25));
 
-		LastAggregator lastAggregator = new LastAggregator(new DoubleDataPointFactoryImpl());
+		LastAggregator lastAggregator = new LastAggregator();
 		lastAggregator.setSampling(new Sampling(5, TimeUnit.MILLISECONDS));
 		lastAggregator.setAlignStartTime(false);
 		DataPointGroup results = lastAggregator.aggregate(group);
@@ -254,7 +289,7 @@ public class LastAggregatorTest
 		group.addDataPoint(new LongDataPoint(7, 5));
 		group.addDataPoint(new LongDataPoint(8, 25));
 
-		LastAggregator lastAggregator = new LastAggregator(new DoubleDataPointFactoryImpl());
+		LastAggregator lastAggregator = new LastAggregator();
 		lastAggregator.setSampling(new Sampling(5, TimeUnit.MILLISECONDS));
 		lastAggregator.setAlignEndTime(true);
 		DataPointGroup results = lastAggregator.aggregate(group);


### PR DESCRIPTION
Changes to the `first` and `last` aggregator to make the work on `string` datapoints.
