### PR TITLE
Make filter aggregator work on String datapoints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: java
 
 jdk:
   - oraclejdk8
+dist: trusty
 
 #services:
 #  - cassandra
@@ -16,4 +17,4 @@ script:
 
 before_install:
   - sudo rm -rf /var/lib/cassandra/*
-  - wget http://www.us.apache.org/dist/cassandra/3.11.4/apache-cassandra-3.11.4-bin.tar.gz && tar -xvzf apache-cassandra-3.11.4-bin.tar.gz && sudo sh apache-cassandra-3.11.4/bin/cassandra -R
+  - wget http://www.us.apache.org/dist/cassandra/3.11.5/apache-cassandra-3.11.5-bin.tar.gz && tar -xvzf apache-cassandra-3.11.5-bin.tar.gz && sudo sh apache-cassandra-3.11.5/bin/cassandra -R

--- a/src/main/java/org/kairosdb/core/aggregator/FilterAggregator.java
+++ b/src/main/java/org/kairosdb/core/aggregator/FilterAggregator.java
@@ -19,6 +19,7 @@ package org.kairosdb.core.aggregator;
 import org.kairosdb.core.DataPoint;
 import org.kairosdb.core.annotation.FeatureComponent;
 import org.kairosdb.core.annotation.FeatureProperty;
+import org.kairosdb.core.datapoints.StringDataPoint;
 import org.kairosdb.core.datastore.DataPointGroup;
 import org.kairosdb.plugin.Aggregator;
 
@@ -33,40 +34,70 @@ public class FilterAggregator implements Aggregator
 	{
 		LTE {
 			@Override
-			boolean compare(double a, double b) {
-				return a <= b;
+			protected <T> boolean compare(Comparable<T> a, T b)
+			{
+				return a.compareTo(b) <= 0;
 			}
 		},
 
 		LT {
 			@Override
-			boolean compare(double a, double b) {
-				return a < b;
+			protected <T> boolean compare(Comparable<T> a, T b)
+			{
+				return a.compareTo(b) < 0;
 			}
 		},
 
 		GTE {
 			@Override
-			boolean compare(double a, double b) {
-				return a >= b;
+			protected <T> boolean compare(Comparable<T> a, T b)
+			{
+				return a.compareTo(b) >= 0;
 			}
 		},
 
 		GT {
 			@Override
-			boolean compare(double a, double b) {
-				return a > b;
+			protected <T> boolean compare(Comparable<T> a, T b)
+			{
+				return a.compareTo(b) > 0;
 			}
 		},
 
 		EQUAL {
 			@Override
-			boolean compare(double a, double b) {
-				return a == b;
+			protected <T> boolean compare(Comparable<T> a, T b)
+			{
+				return a.compareTo(b) ==0;
+			}
+		},
+
+		NE {
+			@Override
+			protected <T> boolean compare(Comparable<T> a, T b)
+			{
+				return a.compareTo(b) !=0;
 			}
 		};
 
-		abstract boolean compare(double a, double b);
+		protected abstract <T> boolean compare(Comparable<T> a, T b);
+
+		boolean filterData(DataPoint dp, Object threshold)
+		{
+			if (String.class.isAssignableFrom(threshold.getClass()) &&
+					StringDataPoint.API_TYPE.equals(dp.getApiDataType()))
+			{
+				return compare(((StringDataPoint)dp).getValue(), threshold.toString());
+			} else if (Number.class.isAssignableFrom(threshold.getClass()) &&
+					!StringDataPoint.API_TYPE.equals(dp.getApiDataType()))
+			{
+				return compare(dp.getDoubleValue(), ((Number)threshold).doubleValue());
+			} else
+			{
+				// data that is not type compatible with the threshold will be filtered
+				return true;
+			}
+		}
 	}
 
     public FilterAggregator()
@@ -85,7 +116,7 @@ public class FilterAggregator implements Aggregator
 			label = "Filter operation",
 			description = "The operation performed for each data point.",
 			type = "enum",
-			options = {"lte", "lt", "gte", "gt", "equal"},
+			options = {"lte", "lt", "gte", "gt", "equal", "ne"},
 			default_value = "equal"
 	)
 	private FilterOperation m_filterop;
@@ -94,7 +125,7 @@ public class FilterAggregator implements Aggregator
 			label = "Threshold",
 			description = "The value the operation is performed on. If the operation is lt, then a null data point is returned if the data point is less than the threshold."
 	)
-	private double m_threshold;
+	private Object m_threshold;
 
 	/**
 	 Sets filter operation to apply to data points. Values can be LTE, LE, GTE, GT, or EQUAL.
@@ -106,7 +137,7 @@ public class FilterAggregator implements Aggregator
 		m_filterop = filterop;
 	}
 
-	public void setThreshold(double threshold)
+	public void setThreshold(Object threshold)
 	{
 		m_threshold = threshold;
 	}
@@ -138,9 +169,10 @@ public class FilterAggregator implements Aggregator
 			boolean foundValidDp = false;
 			while (!foundValidDp && currentDataPoint != null)
 			{
-				double x0 = currentDataPoint.getDoubleValue();
-				if (m_filterop.compare(x0, m_threshold))
+				if (m_filterop.filterData(currentDataPoint, m_threshold))
+				{
 					moveCurrentDataPoint();
+				}
 				else
 					foundValidDp = true;
 			}

--- a/src/test/java/org/kairosdb/core/aggregator/FilterAggregatorTest.java
+++ b/src/test/java/org/kairosdb/core/aggregator/FilterAggregatorTest.java
@@ -18,8 +18,9 @@ package org.kairosdb.core.aggregator;
 
 import org.junit.Test;
 import org.kairosdb.core.DataPoint;
-import org.kairosdb.core.datapoints.DoubleDataPointFactoryImpl;
+import org.kairosdb.core.datapoints.DoubleDataPoint;
 import org.kairosdb.core.datapoints.LongDataPoint;
+import org.kairosdb.core.datapoints.StringDataPoint;
 import org.kairosdb.core.datastore.DataPointGroup;
 import org.kairosdb.testing.ListDataPointGroup;
 
@@ -216,6 +217,125 @@ public class FilterAggregatorTest
 		dp = results.next();
 		assertThat(dp.getTimestamp(), equalTo(6L));
 		assertThat(dp.getLongValue(), equalTo(25L));
+
+		assertThat(results.hasNext(), equalTo(false));
+	}
+
+	@Test
+	public void test_NonEqualToFilter()
+	{
+		ListDataPointGroup group = new ListDataPointGroup("test_ne_values");
+		group.addDataPoint(new LongDataPoint(1, 10));
+		group.addDataPoint(new LongDataPoint(2, 20));
+		group.addDataPoint(new LongDataPoint(3, 15));
+		group.addDataPoint(new LongDataPoint(4, 30));
+		group.addDataPoint(new LongDataPoint(5, 10));
+		group.addDataPoint(new LongDataPoint(6, 25));
+
+		FilterAggregator filterAggregator = new FilterAggregator();
+		filterAggregator.setFilterOp(FilterAggregator.FilterOperation.NE);
+		filterAggregator.setThreshold(10.0);
+		DataPointGroup results = filterAggregator.aggregate(group);
+
+		assertThat(results.hasNext(), equalTo(true));
+		DataPoint dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(1L));
+		assertThat(dp.getLongValue(), equalTo(10L));
+
+		assertThat(results.hasNext(), equalTo(true));
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(5L));
+		assertThat(dp.getLongValue(), equalTo(10L));
+
+		assertThat(results.hasNext(), equalTo(false));
+	}
+
+	@Test
+	public void test_StringFiltering()
+	{
+		ListDataPointGroup group = new ListDataPointGroup("test_string_values");
+		group.addDataPoint(new StringDataPoint(1, "alfa"));
+		group.addDataPoint(new StringDataPoint(2, "beta"));
+		group.addDataPoint(new StringDataPoint(3, "gamma"));
+		group.addDataPoint(new StringDataPoint(4, "delta"));
+		group.addDataPoint(new StringDataPoint(5, "alfa"));
+		group.addDataPoint(new StringDataPoint(6, "beta"));
+
+		FilterAggregator filterAggregator = new FilterAggregator();
+		filterAggregator.setFilterOp(FilterAggregator.FilterOperation.EQUAL);
+		filterAggregator.setThreshold("alfa");
+		DataPointGroup results = filterAggregator.aggregate(group);
+
+		assertThat(results.hasNext(), equalTo(true));
+		DataPoint dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(2L));
+		assertThat(((StringDataPoint)dp).getValue(), equalTo("beta"));
+
+		assertThat(results.hasNext(), equalTo(true));
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(3L));
+		assertThat(((StringDataPoint)dp).getValue(), equalTo("gamma"));
+
+		assertThat(results.hasNext(), equalTo(true));
+		dp = results.next();assertThat(dp.getTimestamp(), equalTo(4L));
+		assertThat(((StringDataPoint)dp).getValue(), equalTo("delta"));
+
+		assertThat(results.hasNext(), equalTo(true));
+		dp = results.next();assertThat(dp.getTimestamp(), equalTo(6L));
+		assertThat(((StringDataPoint)dp).getValue(), equalTo("beta"));
+
+		assertThat(results.hasNext(), equalTo(false));
+	}
+
+	@Test
+	public void test_FilteringMixedTypes()
+	{
+		ListDataPointGroup group = new ListDataPointGroup("test_mixed_types_values");
+		group.addDataPoint(new StringDataPoint(1, "alfa"));
+		group.addDataPoint(new StringDataPoint(2, "beta"));
+		group.addDataPoint(new LongDataPoint(3, 10L));
+		group.addDataPoint(new StringDataPoint(4, "delta"));
+		group.addDataPoint(new DoubleDataPoint(5, 20.0));
+		group.addDataPoint(new StringDataPoint(6, "beta"));
+
+		FilterAggregator filterAggregator = new FilterAggregator();
+		filterAggregator.setFilterOp(FilterAggregator.FilterOperation.GTE);
+		filterAggregator.setThreshold(13.43543);
+		DataPointGroup results = filterAggregator.aggregate(group);
+
+		assertThat(results.hasNext(), equalTo(true));
+		DataPoint dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(3L));
+		assertThat(dp.getDoubleValue(), equalTo(10.0));
+
+		assertThat(results.hasNext(), equalTo(false));
+	}
+
+	@Test
+	public void test_FilteringMixedTypesStringThreshold()
+	{
+		ListDataPointGroup group = new ListDataPointGroup("test_mixed_types_string_thresh_values");
+		group.addDataPoint(new StringDataPoint(1, "alfa"));
+		group.addDataPoint(new StringDataPoint(2, "beta"));
+		group.addDataPoint(new LongDataPoint(3, 10L));
+		group.addDataPoint(new StringDataPoint(4, "delta"));
+		group.addDataPoint(new DoubleDataPoint(5, 20.0));
+		group.addDataPoint(new StringDataPoint(6, "beta"));
+
+		FilterAggregator filterAggregator = new FilterAggregator();
+		filterAggregator.setFilterOp(FilterAggregator.FilterOperation.EQUAL);
+		filterAggregator.setThreshold("beta");
+		DataPointGroup results = filterAggregator.aggregate(group);
+
+		assertThat(results.hasNext(), equalTo(true));
+		DataPoint dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(1L));
+		assertThat(((StringDataPoint)dp).getValue(), equalTo("alfa"));
+
+		assertThat(results.hasNext(), equalTo(true));
+		dp = results.next();
+		assertThat(dp.getTimestamp(), equalTo(4L));
+		assertThat(((StringDataPoint)dp).getValue(), equalTo("delta"));
 
 		assertThat(results.hasNext(), equalTo(false));
 	}

--- a/webroot/index.html
+++ b/webroot/index.html
@@ -1143,6 +1143,7 @@
 			<select class="ui-widget aggregatorFilterOpValue"
 					style="margin-left: 10px;">
 				<option value="equal" selected="selected">EQUAL</option>
+				<option value="ne">NOT EQUAL</option>
 				<option value="lt">LT</option>
 				<option value="lte">LTE</option>
 				<option value="gt">GT</option>

--- a/webroot/js/graph.js
+++ b/webroot/js/graph.js
@@ -158,17 +158,12 @@ function buildKairosDBQuery() {
 				}
 				metric.addScaleAggregator(scalingFactor);
 			}
-                        else if (name == 'filter')
-                        {
-                                var filterop = $(aggregator).find(".aggregatorFilterOpValue").val();
+      else if (name == 'filter')
+      {
+        var filterop = $(aggregator).find(".aggregatorFilterOpValue").val();
 				var threshold = $(aggregator).find(".aggregatorFilterThresholdValue").val();
-				if (!$.isNumeric(threshold))
-				{
-					showErrorMessage("filter threshold value must be a numeric value.");
-					return true;
-				}
-				metric.addFilterAggregator(filterop, threshold);
-                        }
+				metric.addFilterAggregator(filterop, $.isNumeric(threshold) ? parseFloat(threshold) : threshold);
+      }
 			else if (name == 'trim')
 			{
 				var agg = metric.addAggregator(name);


### PR DESCRIPTION
Adapt filter aggregator so it also works on non-numeric datapoints.
Datapoints who's API type is not compatible with the thresholds' type are filtered. If the datapoint's type and the thresholds' type are "compatible", the FilterOperation decides if the datapoint is filtered or not.
Also added a NE (not equal) FilterOperation.