### PR TITLE
Specify custom tags for KairosDB's own metrics.

### DIFF
--- a/src/main/java/org/kairosdb/core/DataPointSet.java
+++ b/src/main/java/org/kairosdb/core/DataPointSet.java
@@ -41,10 +41,14 @@ public class DataPointSet
 		this.m_dataPoints = new ArrayList<>(dataPoints);
 	}
 
-
 	public void addTag(String name, String value)
 	{
 		m_tags.put(name, value);
+	}
+
+	public void addTags(Map<String, String> tags)
+	{
+		m_tags.putAll(tags);
 	}
 
 	@Override

--- a/src/main/java/org/kairosdb/core/reporting/MetricReporterService.java
+++ b/src/main/java/org/kairosdb/core/reporting/MetricReporterService.java
@@ -36,7 +36,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.lang.management.ManagementFactory;
-import java.util.*;
+import java.util.List;
+import java.util.Arrays;
+import java.util.Map;
 
 import static org.kairosdb.util.Preconditions.checkNotNullOrEmpty;
 import static org.quartz.TriggerBuilder.newTrigger;
@@ -65,13 +67,12 @@ public class MetricReporterService implements KairosDBJob
 	private void setCustomTags(@Named("kairosdb.metrics.custom_tags") String customTags)
 	{
 		if (customTags.equals("") || customTags.equals(null)) return;
-		String customTagsString = customTags.replaceAll("\\s+","");
-		List<String> customTagsList = Arrays.asList(customTagsString.split(","));
+		List<String> customTagsList = Arrays.asList(customTags.split(","));
 
 		for (String ctString : customTagsList)
 		{
-			String[] tagValuePair = ctString.split(":");
-			m_customTagsMap.put(tagValuePair[0], tagValuePair[1]);
+			String[] tagValuePair = ctString.split(":", 2);
+			m_customTagsMap.put(tagValuePair[0].trim(), tagValuePair[1].trim());
 		}
 
 		logger.info("KairosDB metrics custom tags defined as: " + m_customTagsMap.toString());

--- a/src/main/resources/kairosdb.conf
+++ b/src/main/resources/kairosdb.conf
@@ -5,6 +5,11 @@ kairosdb: {
 	# The default setting is ALL, which will enable all API methods.
 	#server.type: "ALL"
 
+	# Specify a list of custom tags to add to KairosDB's own internal metrics. Examples might include environment, or data_center.
+	# This should be a comma-delimited list of tag:tag-value pairs in a string. Example: "environment:AWSLAB, data_center:US-EAST-1"
+	# Each pair should be the tag and tag-value separated by a colon ":".
+	#metrics.custom_tags: ""
+
 	# Properties that start with kairosdb.service are services that are started
 	# when kairos starts up.  You can disable services in your custom
 	# kairosdb.conf file by setting the value to <disabled> ie

--- a/src/main/resources/kairosdb.conf
+++ b/src/main/resources/kairosdb.conf
@@ -5,9 +5,14 @@ kairosdb: {
 	# The default setting is ALL, which will enable all API methods.
 	#server.type: "ALL"
 
-	# Specify a list of custom tags to add to KairosDB's own internal metrics. Examples might include environment, or data_center.
-	# This should be a comma-delimited list of tag:tag-value pairs in a string. Example: "environment:AWSLAB, data_center:US-EAST-1"
-	# Each pair should be the tag and tag-value separated by a colon ":".
+	# Specify a comma-delimited list of custom tags to add to KairosDB's own internal metrics. Example tags might
+	# include environment, or data_center. This should be a comma separated list of tag:tag-value pairs in a string,
+	# with each tag separated from it's tag value by a colon ":". The tag/tag value pair is split on the first colon, so
+	# tag names cannot include the colon character, but tag values can. Spaces will also be trimmed from
+	# the front and back of the tag name and tag value, but not from within the tag or tag value. Commas are obviously
+	# restricted.
+	# Example string defining two custom tags: "environment:AWSLAB, data center:US-EAST-1"
+	# The default is to not have any custom tags defined.
 	#metrics.custom_tags: ""
 
 	# Properties that start with kairosdb.service are services that are started


### PR DESCRIPTION
This will allow configuration of a set of custom tags to add to KairosDB's own internal metrics. This can help when running several KairosDB instances of different server types (ingest/query/delete), in different environments or data centers, etc., to allow better grouping when querying for Kairos' own metrics.

Custom tags are specified in kairosdb.conf under the kairosdb.metrics.custom_tags setting as a string consisting of a comma-delimited list of tag:tag value pairs. After the string is split on the commas, the pairs are separated after the first instance of a colon, and white space is trimmed from the beginning and end of each tag name and tag value. This allows for the use of whitespace within the tag names and tag values, and colons within the tag values.