### PR TITLE
adds configurable process tags for kairos internal metrics

### DIFF
--- a/src/main/java/org/kairosdb/core/DataPointSet.java
+++ b/src/main/java/org/kairosdb/core/DataPointSet.java
@@ -41,10 +41,13 @@ public class DataPointSet
 		this.m_dataPoints = new ArrayList<>(dataPoints);
 	}
 
-
 	public void addTag(String name, String value)
 	{
 		m_tags.put(name, value);
+	}
+
+	public void addTags(Map<String, String> tags)	{
+		m_tags.putAll(tags);
 	}
 
 	@Override

--- a/src/main/java/org/kairosdb/core/reporting/MetricReportingModule.java
+++ b/src/main/java/org/kairosdb/core/reporting/MetricReportingModule.java
@@ -36,10 +36,10 @@ public class MetricReportingModule extends ServletModule
 		filter("/*").through(MonitorFilter.class);
 
 		bind(DataPointsMonitor.class).in(Scopes.SINGLETON);
-
+		bind(ProcessTagConfiguration.class).in(Scopes.SINGLETON);
 		KairosMetricReporterListProvider reporterProvider = new KairosMetricReporterListProvider();
 		bind(KairosMetricReporterListProvider.class).toInstance(reporterProvider);
-
+		requestStaticInjection(ThreadReporter.class);
 		bindListener(Matchers.any(), reporterProvider);
 	}
 }

--- a/src/main/java/org/kairosdb/core/reporting/ProcessTagConfiguration.java
+++ b/src/main/java/org/kairosdb/core/reporting/ProcessTagConfiguration.java
@@ -1,0 +1,35 @@
+package org.kairosdb.core.reporting;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.ConfigObject;
+import com.typesafe.config.ConfigValue;
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import org.kairosdb.core.KairosRootConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ProcessTagConfiguration {
+	public static final Logger logger = LoggerFactory.getLogger(ProcessTagConfiguration.class);
+	private final ImmutableMap<String, String> m_processTags;
+
+	@Inject
+	public ProcessTagConfiguration(KairosRootConfig config) {
+		if (config.hasPath("kairosdb.metrics.custom_tags")) {
+			ConfigObject tagObject = config.getRawConfig().getObject("kairosdb.metrics.custom_tags");
+			Map<String, String> tags = new HashMap<>();
+			for(Map.Entry<String, ConfigValue> entry : tagObject.entrySet()) {
+				tags.put(entry.getKey(), entry.getValue().unwrapped().toString());
+			}
+			m_processTags = ImmutableMap.copyOf(tags);
+			logger.info("Using process tag set {}", m_processTags);
+		} else {
+			m_processTags = ImmutableMap.of();
+		}
+	}
+
+	public ImmutableMap<String, String> getTags(){
+		return this.m_processTags;
+	}
+}

--- a/src/main/java/org/kairosdb/core/reporting/ThreadReporter.java
+++ b/src/main/java/org/kairosdb/core/reporting/ThreadReporter.java
@@ -17,6 +17,10 @@
 package org.kairosdb.core.reporting;
 
 import com.google.common.collect.ImmutableSortedMap;
+import java.util.LinkedList;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import javax.inject.Inject;
 import org.kairosdb.core.datapoints.LongDataPointFactory;
 import org.kairosdb.core.datapoints.StringDataPointFactory;
 import org.kairosdb.core.exception.DatastoreException;
@@ -24,10 +28,6 @@ import org.kairosdb.eventbus.Publisher;
 import org.kairosdb.events.DataPointEvent;
 import org.kairosdb.util.StatsMap;
 import org.kairosdb.util.Tags;
-
-import java.util.LinkedList;
-import java.util.SortedMap;
-import java.util.TreeMap;
 
 /**
  Created with IntelliJ IDEA.
@@ -79,7 +79,12 @@ public class ThreadReporter
 		public int getTtl() { return (m_ttl); }
 		public boolean isStringValue() { return m_strValue != null; }
 
-		public ImmutableSortedMap<String, String> getTags() { return m_tags.build(); }
+		public ImmutableSortedMap<String, String> getTags() {
+			if (processTags != null) {
+				m_tags.putAll(processTags.getTags());
+			}
+			return m_tags.build();
+		}
 	}
 
 	private static class CurrentTags extends ThreadLocal<SortedMap<String, String>>
@@ -127,6 +132,9 @@ public class ThreadReporter
 	private static ReporterData s_reporterData = new ReporterData();
 	private static CurrentTags s_currentTags = new CurrentTags();
 	private static ReporterTime s_reportTime = new ReporterTime();
+
+	@Inject
+	private static ProcessTagConfiguration processTags;
 
 	private ThreadReporter()
 	{

--- a/src/main/resources/kairosdb.conf
+++ b/src/main/resources/kairosdb.conf
@@ -5,6 +5,14 @@ kairosdb: {
 	# The default setting is ALL, which will enable all API methods.
 	#server.type: "ALL"
 
+	# Specify a map of custom tags to add to KairosDB's own internal metrics. Example tags might
+	# include environment, data center or server role/type. This should resolve to a JSON object of key/value pairs
+	# Example defining two custom tags:
+	# metrics.custom_tags.environment: "AWSLAB"
+	# metrics.custom_tags."data center": "US-EAST-1"
+	# The default is to not have any custom tags defined.
+	#metrics.custom_tags."server.type": "INGEST"
+
 	# Properties that start with kairosdb.service are services that are started
 	# when kairos starts up.  You can disable services in your custom
 	# kairosdb.conf file by setting the value to <disabled> ie


### PR DESCRIPTION
Adds custom metric tags for kairosdb process metrics. as per recommendations in a previous pull request #584

This PR should replace #584. Takes advantage of hocon data structure to provide key/values.