### PR TITLE
Correct interpretation of negative end_absolute

### DIFF
--- a/src/main/java/org/kairosdb/core/http/rest/json/QueryParser.java
+++ b/src/main/java/org/kairosdb/core/http/rest/json/QueryParser.java
@@ -153,13 +153,13 @@ public class QueryParser
 		}
 	}
 
-	private long getEndTime(Query request)
+	private Optional<Long> getEndTime(Query request)
 	{
 		if (request.getEndAbsolute() != null)
-			return request.getEndAbsolute();
+			return Optional.of(request.getEndAbsolute());
 		else if (request.getEndRelative() != null)
-			return request.getEndRelative().getTimeRelativeTo(System.currentTimeMillis());
-		return -1;
+			return Optional.of(request.getEndRelative().getTimeRelativeTo(System.currentTimeMillis()));
+		return Optional.empty();
 	}
 
 
@@ -233,9 +233,7 @@ public class QueryParser
 				queryMetric.setExcludeTags(metric.isExcludeTags());
 				queryMetric.setLimit(metric.getLimit());
 
-				long endTime = getEndTime(query);
-				if (endTime > -1)
-					queryMetric.setEndTime(endTime);
+				getEndTime(query).ifPresent(queryMetric::setEndTime);
 
 				if (queryMetric.getEndTime() < startTime)
 					throw new BeanValidationException(new SimpleConstraintViolation("end_time", "must be greater than the start time"), context);

--- a/src/test/java/org/kairosdb/core/http/rest/json/QueryParserTest.java
+++ b/src/test/java/org/kairosdb/core/http/rest/json/QueryParserTest.java
@@ -77,6 +77,21 @@ public class QueryParserTest
 	}
 
 	@Test
+	public void test_negative_absolute_dates() throws QueryException, IOException
+	{
+		String json = Resources.toString(Resources.getResource("query-metric-negative-absolute-dates.json"), Charsets.UTF_8);
+
+		List<QueryMetric> results = parser.parseQueryMetric(json).getQueryMetrics();
+
+		assertThat(results.size(), equalTo(1));
+
+		QueryMetric queryMetric = results.get(0);
+		assertThat(queryMetric.getName(), equalTo("abc.123"));
+		assertThat(queryMetric.getStartTime(), equalTo(-200L));
+		assertThat(queryMetric.getEndTime(), equalTo(-100L));
+	}
+
+	@Test
 	public void test_withNoAggregators() throws Exception
 	{
 		String json = Resources.toString(Resources.getResource("invalid-query-metric-no-aggregators.json"), Charsets.UTF_8);

--- a/src/test/resources/query-metric-negative-absolute-dates.json
+++ b/src/test/resources/query-metric-negative-absolute-dates.json
@@ -1,0 +1,22 @@
+{
+	"start_absolute": -200,
+	"end_absolute": -100,
+	"metrics": [
+		{
+			"name": "abc.123",
+			"aggregators":[
+				{
+					"name":"sum",
+					"sampling": {
+						"value": "1",
+						"unit": "milliseconds"
+					}
+				}
+			],
+			"tags": {
+				"host": "foo",
+				"type": "bar"
+			}
+		}
+	]
+}


### PR DESCRIPTION
Correctly interpret a negative value for the end_absolute field
in a query, instead of using a negative value to represent
"no data".

Resolves #601