### PR TITLE
Use HTTPS for maven central

### DIFF
--- a/ivysettings.xml
+++ b/ivysettings.xml
@@ -6,7 +6,7 @@
 		         changingPattern=".*SNAPSHOT"/>
 		<!--<ibiblio name="my-maven" m2compatible="true" root="http://repo.maven.apache.org/maven2/"/>-->
 		<!--<ibiblio name="staging" m2compatible="true" root="https://oss.sonatype.org/content/repositories/orgagileclick-1008"/>-->
-		<ibiblio name="central" m2compatible="true"/>
+		<ibiblio name="central" m2compatible="true" root="https://repo1.maven.org/maven2/" />
 
 		<filesystem name="local-m2-publish" m2compatible="true">
 			<artifact


### PR DESCRIPTION
On Jan 15th 2020, Sonatype moved Maven Central to HTTPS with no automatic HTTP redirect.

This patch adds the normal root of maven central but with an HTTPS URL.


See here for details:  
https://blog.sonatype.com/central-repository-moving-to-https 
https://support.sonatype.com/hc/en-us/articles/360041287334

