### PR TITLE
Official docker support.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+build
+.git
+.tablesawcache
+.travis.yml
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+ARG KAIROSDB_VERSION=1.3.0-0.1beta
+
+FROM openjdk:8u242-jdk-slim-buster as build
+ARG KAIROSDB_VERSION
+
+WORKDIR /home/kairosdb
+ADD . /home/kairosdb/git
+
+RUN cd git && \
+    export CLASSPATH=tools/tablesaw-1.2.7.jar && \
+    java make package
+
+RUN tar -xzvf git/build/kairosdb-${KAIROSDB_VERSION}.tar.gz
+
+FROM openjdk:8u242-jdk-slim-buster
+ARG KAIROSDB_VERSION
+ENV KAIROSDB_HOME=/opt/kairosdb-${KAIROSDB_VERSION}
+ENV CLASSPATH=${KAIROSDB_HOME}/lib/*
+
+COPY --from=build /home/kairosdb/kairosdb /opt/kairosdb-${KAIROSDB_VERSION}
+
+RUN ln -s ${KAIROSDB_HOME}/conf /etc/kairosdb && \
+    echo 'export PATH=${KAIROSDB_HOME}/bin:${PATH}' >> /root/.bashrc
+
+EXPOSE 8080 4242
+
+WORKDIR /opt/kairosdb-${KAIROSDB_VERSION}/bin
+ENTRYPOINT . ~/.bashrc && kairosdb.sh run

--- a/how_to_build.txt
+++ b/how_to_build.txt
@@ -8,3 +8,7 @@ Then to build type
 
 You can also get help on what targets are available by typing
 >java make help
+
+If you prefer to use docker you can easily run the following commands from the top folder of this repository:
+>docker build -t kairosdb:1.3.0_beta1 .
+>docker run -it --rm -p 0.0.0.0:8080:8080 -p 0.0.0.0:4242:4242 kairosdb:1.3.0_beta1


### PR DESCRIPTION
I have added a dockerfile which builds a container which automatically starts the kairosdb instance. I also updated the how to build in case someone prefers to test the build in Docker rather than on his local host OS.

The build is made within Docker and follows exactly the steps from **how_to_build.txt** document.

Fixes #288 .