### PR TITLE
Official helm chart for kairosdb.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Download the latest [KairosDB release](https://github.com/kairosdb/kairosdb/rele
 
 Installation instructions are found [here](http://kairosdb.github.io/docs/build/html/GettingStarted.html)
 
+If you want to test KairosDB in Kubernetes please follow the instructions from [KairosDB Helm chart](deployment/helm/README.md).
+
 ## Getting Involved
 
 Join the [KairosDB discussion group](https://groups.google.com/forum/#!forum/kairosdb-group).

--- a/deployment/helm/.helmignore
+++ b/deployment/helm/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deployment/helm/Chart.yaml
+++ b/deployment/helm/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.3.0"
+description: A Helm chart for installing and configuring kairosdb TSDB in Kubernetes.
+name: kairosdb
+version: 0.1.0

--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -1,0 +1,35 @@
+This is the official helm chart for installing KairosDB in a kubernetes cluster. At the moment,
+we support configuring the following backends:
+
+* H2
+* Cassandra
+
+# Getting started
+
+In order to test the KairosDB installation within a kubernetes cluster with an external cassandra you can try the following commands:
+
+```bash
+kind create cluster
+export KUBECONFIG=~/.kube/config
+
+cd deployment/helm
+helm install -f values.yaml --set storage.cassandra.enabled=true \
+    --set storage.h2.enabled=false \
+    --set storage.cassandra.contactPoints=192.168.1.103 \
+    --set replicaCount=3 \
+    test .
+kubectl get pods # wait until the container starts and is in state running
+kubectl port-forward svc/test-kairosdb 8080:80 # you should now be able to access kairosdb on localhost:8080
+```
+
+You should use **helm 3** and kind **0.7.0** but the chart is also compatible with newer versions of **helm 2** (>v2.14.0).
+In the above example we use kind only for demo purposes.
+The contact points should be the valid comma separated list of cassandra nodes listening on port 9042.
+
+If you want to test with a local cassandra instance you can use the following command:
+
+```bash
+docker run -it --rm -p 0.0.0.0:9042:9042 cassandra:latest # this will run a local instance of cassandra.
+```
+
+For more customisation options, please consult the **values.yaml** file.

--- a/deployment/helm/templates/NOTES.txt
+++ b/deployment/helm/templates/NOTES.txt
@@ -1,0 +1,2 @@
+KairosDB has been officially installed in your K8S cluster. If you want to start publishing metrics
+you can use http://{{ include "kairosdb.fullname" . }}:{{ .Values.service.port }} endpoint.

--- a/deployment/helm/templates/_helpers.tpl
+++ b/deployment/helm/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kairosdb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kairosdb.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kairosdb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "kairosdb.labels" -}}
+app.kubernetes.io/name: {{ include "kairosdb.name" . }}
+helm.sh/chart: {{ include "kairosdb.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/deployment/helm/templates/config.yaml
+++ b/deployment/helm/templates/config.yaml
@@ -1,0 +1,403 @@
+{{- if .Values.enabled }}
+
+{{- $cassandraContactPoints := .Values.storage.cassandra.contactPoints }}
+
+---
+apiVersion: v1
+kind: ConfigMap 
+metadata:
+  name: kairosdb-config
+  labels:
+{{ include "kairosdb.labels" . | indent 4 }}
+data:
+  kairosdb.conf: |
+    kairosdb: {
+            server.type: "ALL"
+            
+            {{ if not .Values.configuration.telnet.enabled }}
+            kairosdb.service.telnet=<disabled>
+            {{ end }}
+
+            service.telnet: "org.kairosdb.core.telnet.TelnetServerModule"
+            telnetserver: {
+                    port: {{ .Values.configuration.telnet.port }}
+                    address: "0.0.0.0"
+                    max_command_size: {{ .Values.configuration.telnet.maxCommandSize }}
+            }
+
+            #===============================================================================
+            service.http = org.kairosdb.core.http.WebServletModule
+            jetty: {
+                    port: 8080
+                    address: "0.0.0.0"
+                    static_web_root: "webroot"
+                    show_stacktrace: false
+
+
+                    # To enable thread pooling uncomment the following lines and specify the limits
+                    #threads.queue_size: 6000
+                    #threads.min: 1000
+                    #threads.max: 2500
+                    #threads.keep_alive_ms: 10000
+            }
+
+            #===============================================================================
+            # Each factory must be bound in a guice module.  The definition here defines what
+            # protocol data type the factory services.
+            datapoints.factory: {
+                    long: "org.kairosdb.core.datapoints.LongDataPointFactoryImpl"
+                    double: "org.kairosdb.core.datapoints.DoubleDataPointFactoryImpl"
+                    string: "org.kairosdb.core.datapoints.StringDataPointFactory"
+            }
+
+            #===============================================================================
+            service.reporter = org.kairosdb.core.reporting.MetricReportingModule
+            reporter: {
+                    # Uses Quartz Cron syntax - default is to run every minute
+                    schedule: "0 */1 * * * ?"
+                    # TTL to apply to all kairos reported metrics
+                    ttl: 0
+            }
+
+            #===============================================================================
+            #Configure the datastore
+
+            {{ if .Values.storage.h2.enabled }}
+            service.datastore: "org.kairosdb.datastore.h2.H2Module"
+            {{ else if .Values.storage.cassandra.enabled }}
+            service.datastore: "org.kairosdb.datastore.cassandra.CassandraModule"
+            {{ end }}
+
+            datastore.concurrentQueryThreads: 5
+
+            datastore.h2.database_path: "build/h2db"
+
+            datastore.cassandra: {
+                    table_create_with: {
+                            data_points: "WITH COMPACT STORAGE"
+                            row_key_index: ""
+                            row_key_time_index: ""
+                            row_keys: ""
+                            tag_indexed_row_keys: ""
+                            string_index: ""
+                            service_index: ""
+                    }
+
+                    #For a single metric query this dictates the number of simultaneous cql queries
+                    #to run (ie one for each partition key of data).  The larger the cluster the higher you may want
+                    #this number to be.
+                    simultaneous_cql_queries: {{ .Values.configuration.cassandra.maxConcurrentMetricQueries }}
+
+                    # query_reader_threads is the number of threads to use to read results from
+                    # each cql query.  You may want to change this number depending on your environment
+                    query_reader_threads: {{ .Values.configuration.cassandra.maxQueryReaderThreads }}
+
+                    {{ if .Values.configuration.queryLimit.enabled }}
+                    # When set, the query_limit will prevent any query reading more than the specified
+                    # number of data points.  When the limit is reached an exception is thrown and an
+                    # error is returned to the client.  Set this value to 0 to disable (default)
+                    query_limit: {{ .Values.configuration.queryLimit.maxDataPoints }}
+
+                    # When set, the query_time_limit_sec will try to prevent any query from taking
+                    # longer than the number of seconds specified.  This time is measuered while
+                    # doing actual work against Cassandra.  A query could be blocked on slower queries
+                    # at a higher level and actually take longer than the specified time.
+                    query_time_limit_sec: {{ .Values.configuration.queryLimit.timeoutSec }}
+                    {{ end }}
+
+                    //Todo this is wrong
+                    #Size of the row key cache size.  This can be monitored by querying
+                    #kairosdb.datastore.cassandra.write_batch_size.sum and filtering on the tag table = row_keys
+                    #Ideally the data written to the row_keys should stabilize to zero except
+                    #when data rolls to a new row
+                    row_key_cache_size: 50000
+                    string_cache_size: 50000
+
+                    #the time to live in seconds for datapoints. After this period the data will be
+                    #deleted automatically. If not set the data will live forever.
+                    #TTLs are added to columns as they're inserted so setting this will not affect
+                    #existing data, only new data.
+                    datapoint_ttl: {{ .Values.configuration.dataPointTTL }}
+
+                    #When start_async is set to true a background thread is created to try and
+                    #connect to cassandra when starting up Kairos.  This allows Kairos to start
+                    #even if Cassandra is not yet available.  The background thread repeatedly
+                    #attempts to connect every 1sec until it is successful.
+                    #Setting start_async to false means kairos will fail to start if Cassandra
+                    #is not available.
+                    start_async: false
+
+                    # This identifies the cluster, metrics are written to.  The write_cluster also
+                    # participates in any metric query.  If you only have one C* cluster then
+                    # it must be specified as the write_cluster
+                    write_cluster: {
+                            # name of the cluster as it shows up in client specific metrics
+                            name: "write_cluster"
+                            keyspace: "kairosdb"
+                            replication: "{'class': 'SimpleStrategy','replication_factor' : {{ .Values.configuration.cassandra.replicationFactor }}}"
+                            cql_host_list: [
+                                {{ if .Values.storage.cassandra.enabled }}
+                                {{ range $idx, $contactPoint := ($cassandraContactPoints | split ",") }}
+                                "{{ $contactPoint }}",
+                                {{- end }}
+                                {{- end -}}
+                            ]
+
+                            # Set this if this kairosdb node connects to cassandra nodes in multiple datacenters.
+                            # Not setting this will select cassandra hosts using the RoundRobinPolicy, while setting this will use DCAwareRoundRobinPolicy.
+                            #local_dc_name: "<local dc name>"
+
+                            #Control the required consistency for cassandra operations.
+                            #Available settings are cassandra version dependent:
+                            #http://www.datastax.com/documentation/cassandra/2.0/webhelp/index.html#cassandra/dml/dml_config_consistency_c.html
+                            read_consistency_level: "{{ .Values.configuration.cassandra.readConsistency }}"
+                            write_consistency_level: "{{ .Values.configuration.cassandra.writeConsistency }}"
+
+                            #protocol compression to use in the Cassandra client.  Available values are
+                            #LZ4, SNAPPY, NONE.  Defaults to LZ4
+                            protocol_compression: "LZ4"
+
+                            #The number of times to retry a request to C* in case of a failure.
+                            request_retry_count: 2
+
+                            connections_per_host: {
+                                    local.core: {{ .Values.configuration.cassandra.connection.localCores }}
+                                    local.max: {{ .Values.configuration.cassandra.connection.maxLocalCores }}
+
+                                    remote.core: {{ .Values.configuration.cassandra.connection.remoteCores }}
+                                    remote.max: {{ .Values.configuration.cassandra.connection.maxRemoteCores }}
+                            }
+
+                            # If using cassandra 3.0 or latter consider increasing this value
+                            max_requests_per_connection: {
+                                    local: {{ .Values.configuration.cassandra.connection.maxRequestsPerLocalConnection }}
+                                    remote: {{ .Values.configuration.cassandra.connection.maxRequestsPerRemoteConnection }}
+                            }
+
+                            max_queue_size: {{ .Values.configuration.queueSize }}
+
+                            # Set this property to true to enable SSL connections to your C* cluster.
+                            # Follow the instructions found here: http://docs.datastax.com/en/developer/java-driver/3.1/manual/ssl/
+                            # to create a keystore and pass the values into Kairos using the -D switches
+                            use_ssl: false
+
+                            tag_indexed_row_key_lookup_metrics: []
+                    }
+
+                    # Rename this to read_clusters in order for it to be used
+                    # This is for additional clusters of old data that you want to make available
+                    # for queries.  The cql_host_list SHOULD NOT point to the same cluster as
+                    # the write_cluster above.
+                    # All properties found in the write_cluster section can be used here as well
+                    # As this property is a list you can specify 0 or more read clusters.
+                    # The idea behind read_clusters is so you can manage data growth, so instead
+                    # of adding more nodes to an older C* cluster you can create new clusters
+                    # on newer versions of C*.  Older clusters can then be turned off or shrunk.
+                    read_clusters_not: []
+            }
+
+
+            #===============================================================================
+            # Determines if cache files are deleted after being used or not.
+            # In some cases the cache file can be used again to speed up subsequent queries
+            # that query the same metric but aggregate the results differently.
+            query_cache.keep_cache_files: false
+
+            # Cache file cleaning schedule. Uses Quartz Cron syntax - this only matters if
+            # keep_cache_files is set to true
+            query_cache.cache_file_cleaner_schedule: "0 0 12 ? * SUN *"
+
+            #By default the query cache is located in kairos_cache under the system temp folder as
+            #defined by java.io.tmpdir system property.  To override set the following value
+            #query_cache.cache_dir: ""
+
+            #===============================================================================
+            # Log long running queries, set this to true to record long running queries
+            # into kairos as the following metrics.
+            # kairosdb.log.query.remote_address - String data point that is the remote address
+            #   of the system making the query
+            # kairosdb.log.query.json - String data point that is the query sent to Kairos
+            log.queries: {
+                    enable: false
+
+                    # Time to live to apply to the above metrics.  This helps limit the mount of space
+                    # used for storing the query information
+                    ttl: 86400
+
+                    # Time in seconds.  If the query request time is longer than this value the query
+                    # will be written to the above metrics
+                    greater_than: 60
+            }
+
+            # When set to true the query stats are aggregated into min, max, avg, sum, count
+            # Setting to true will also disable the above log feature.
+            # Set this to true on Kairos nodes that receive large numbers of queries to save
+            # from inserting data witch each query
+            queries.aggregate_stats = false
+
+            # If a tag filter value begins with this string the remaining is considered a
+            # regex to match against those tag values.  ei {"host": "regex:server1[0-2]"}
+            # matches host tag values server10, server11 and server12
+            # set the value to an empty string to disable
+            queries.regex_prefix = "regex:"
+
+            #When set to true Kairos will insert the query into the response json as
+            #original_query.  This is useful for some processes that send queries asynchronously
+            #and need a way to identify responses.
+            queries.return_query_in_response = false
+
+            #===============================================================================
+            # Health Checks
+            service.health: "org.kairosdb.core.health.HealthCheckModule"
+
+            #Response code to return from a call to /api/v1/health/check
+            #Some load balancers want 200 instead of 204
+            health.healthyResponseCode: 204
+
+            #===============================================================================
+            #Ingest queue processor
+            # The MemoryQueueProcessor keeps everything in memory before batching to
+            # cassandra and blocks when the queue is full
+            # The FileQueueProcessor uses a hybrid memory queue and a file backed queue
+            # Data is placed in both memory and in the file queue before a client response
+            # is sent.  Data is read from file only when the lag is greater than what the
+            # memory queue can hold
+
+            queue_processor: {
+                    #class: "org.kairosdb.core.queue.MemoryQueueProcessor"
+                    class: "org.kairosdb.core.queue.FileQueueProcessor"
+
+                    # The number of data points to send to Cassandra
+                    # For the best performance you will want to set this to 10000 but first
+                    # you will need to change the following values in your cassandra.yaml
+                    # batch_size_warn_threshold_in_kb: 50
+                    # batch_size_fail_threshold_in_kb: 70
+                    # You may need to adjust the above numbers to fit your insert patterns.
+                    # The CQL batch has a hard limit of 65535 items in a batch, make sure to stay
+                    # under this as a single data point can generate more than one insert into Cassandra
+                    # You will want to multiply this number by the number of hosts in the Cassandra
+                    # cluster.  A batch is pulled from the queue and then divided up depending on which
+                    # host the data is destined for.
+                    # If you set this value higher you may also get warnings in C* about Unlogged batches
+                    # covering x number of partitions.  You can remove this warning by increaseing the value
+                    # of this property in cassandra.yaml
+                    # unlogged_batch_across_partitions_warn_threshold: 100
+                    batch_size: {{ .Values.configuration.cassandra.dataPointsToSend }}
+
+                    # If the queue doesn't have at least this many items to process the process thread
+                    # will pause for .5 seconds to wait for more before grabbing data from the queue.
+                    # This is an attempt to prevent chatty inserts which can cause extra load on
+                    # Cassandra
+                    min_batch_size: {{ .Values.configuration.cassandra.minDataPointsToSend }}
+
+                    # If the number of items in the process queue is less than {min_batch_size} the
+                    # queue processor thread will wait this many milliseconds before flushing the data
+                    # to C*.  This is to prevent single chatty inserts.  This only has effect when
+                    # data is trickling in to Kairos.
+                    min_batch_wait: {{ .Values.configuration.cassandra.minBatchWaitMs }}
+
+                    # The size (number of data points) of the memory queue
+                    # In the case of FileQueueProcessor:
+                    # Ingest data is written to the memory queue as well as to disk.  If the system gets
+                    # behind the memory queue is overrun and data is read from disk until it can
+                    # catch up.
+                    # In the case of MemoryQueueProcessor it defines the size of the memory queue.
+                    memory_queue_size: {{ .Values.configuration.cassandra.memoryQueueSize }}
+
+                    # The number of seconds before checkpointing the file backed queue.  In the case of
+                    # a crash the file backed queue is read from the last checkpoint
+                    # Only applies to the FileQueueProcessor
+                    seconds_till_checkpoint: {{ .Values.configuration.cassandra.secondsTillCheckpointSec }}
+
+                    # Path to the file backed queue
+                    # Only applies to the FileQueueProcessor
+                    queue_path: "queue"
+
+                    # Page size of the file backed queue 50Mb
+                    # Only applies to the FileQueueProcessor
+                    page_size: {{ .Values.configuration.cassandra.pageSizeBytes }}
+            }
+
+            #Number of threads allowed to insert data to the backend
+            #CassandraDatastore is the only use of this executor
+            ingest_executor.thread_count = {{ .Values.configuration.cassandra.maxThreadCount }}
+
+
+            # The HostManager serivce keeps track of other kairos nodes in the cluster
+            # (ie that are talking to the same cassandra cluster).  It does this by
+            # writing data to a serivce key and updating it periodically.  The following
+            # settings define how often it checks the key for other hosts and when to mark
+            # them as inactive.  This is primarily used for balancing rollup jobs
+            host_service_manager: {
+                    check_delay_time_millseconds: 30000
+                    inactive_time_seconds: 30
+            }
+
+            # This filters and prevents specified metrics from being ingested.
+            # This can be used to turn off kairos internal metrics or stop a flow of
+            # metrics that have to many tags, etc.  Uncomment the module and then
+            # specify the filters to put in place.
+            #service.filter: "org.kairosdb.filter.FilterModule"
+            filter: {
+                    # this does exact match filtering
+                    list: [
+                            ]
+                    # this does prefix match filtering
+                    prefix: [
+                            ]
+                    # this filters using regex's
+                    regex: [
+                            ]
+            }
+
+            # sets the priority of the filter plugin so it can remove events before
+            # the datastore gets them.
+            eventbus.filter.priority.org.kairosdb.filter.FilterPlugin: 25
+
+
+    #===============================================================================
+    # Roll-ups
+            #service.rollups=org.kairosdb.rollup.RollUpModule
+
+            # How often the Roll-up Manager queries for new or updated roll-ups\
+            #rollups: {
+            #       server_assignment {
+            #                       check_update_delay_millseconds = 10000
+            #               }
+            #       }
+            #===============================================================================
+
+
+            #===============================================================================
+            #Demo and stress modules
+
+            # The demo module will load one years of data into kairos.  The code goes back
+            # one year from the present and inserts data every minute.  The data makes a
+            # pretty little sign wave.
+
+            #service.demo: "org.kairosdb.core.demo.DemoModule"
+            demo: {
+                    metric_name: "demo_data"
+                    # number of rows = number of host tags to add to the data. Setting the number_of_rows
+                    # to 100 means 100 hosts reporting data every minutes, each host has a different tag.
+                    number_of_rows: 100
+                    ttl: 0
+            }
+
+
+            # This just inserts data as fast as it can for the duration specified.  Good for
+            # stress testing your backend.  I have found that a single Kairos node will only
+            # send about 500k/sec because of a limitation in the cassandra client.
+
+            #service.blast: "org.kairosdb.core.blast.BlastModule"
+            # The number_of_rows translates into a random number between 0 and number_of_rows
+            # that is added as a tag to each data point.  Trying to simulate a even distribution
+            # data in the cluster.
+            blast: {
+                    number_of_rows: 1000
+                    duration_seconds: 30
+                    metric_name: "blast_load"
+                    ttl: 600
+            }
+    }
+{{- end }}

--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.enabled -}}
+{{- $waitCfgName := printf "kairosdb-wait-cfg" -}}
+{{- $maxCassandraNodes := (split "," .Values.storage.cassandra.contactPoints | len) -}}
+{{- $dbHost := printf "%s" .Values.storage.cassandra.contactPoints }}
+
+apiVersion: v1
+kind: ConfigMap 
+metadata:
+  name: {{ $waitCfgName }}
+  labels:
+{{ include "kairosdb.labels" . | indent 4 }}
+data:
+  config.json: |
+    [
+      {{- if .Values.storage.cassandra.enabled -}}
+        {{ range $i, $e := (split "," $dbHost) -}}
+        {
+          "host": "{{ $e }}",
+          "port": {{ $.Values.storage.cassandra.port }},
+          "type": "cassandra"
+        }{{ if lt ((trimPrefix "_" $i) | int | add 1) $maxCassandraNodes }},{{ end }}
+        {{- end }}
+      {{- end }}
+    ]
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kairosdb.fullname" . }}
+  labels:
+{{ include "kairosdb.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "kairosdb.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "kairosdb.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      initContainers:
+        - name: {{ .Release.Name }}-raw-data-wait
+          image: {{ .Values.image.waitContainer.image.repository }}:{{ .Values.image.waitContainer.image.tag }}
+          imagePullPolicy: {{ .Values.image.waitContainer.image.pullPolicy }}
+          args: [ "/etc/config/config.json" ]
+          volumeMounts:
+            - name: wait-config-volume
+              mountPath: /etc/config
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: [ "bash" ]
+          args:
+            - "-c"
+            - "cp -f /etc/kairosdb/custom-configs/*.conf /etc/kairosdb && . ~/.bashrc && kairosdb.sh run"
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          volumeMounts:
+            - name: kairos-config-volume
+              mountPath: /etc/kairosdb/custom-configs
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: wait-config-volume
+          configMap:
+            name: {{ $waitCfgName }}
+        - name: kairos-config-volume
+          configMap:
+            name: kairosdb-config
+            items:
+              - key: kairosdb.conf
+                path: kairosdb.conf
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/deployment/helm/templates/ingress.yaml
+++ b/deployment/helm/templates/ingress.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "kairosdb.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+{{ include "kairosdb.labels" . | indent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .http.paths }}
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/deployment/helm/templates/service.yaml
+++ b/deployment/helm/templates/service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "kairosdb.fullname" . }}
+  labels:
+{{ include "kairosdb.labels" . | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "kairosdb.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{ end }}

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -1,0 +1,96 @@
+replicaCount: 1
+enabled: true
+
+image:
+  repository: rcosnita/kairosdb # this must be changed when we onboard kairosdb to official dockerhub repository.
+  tag: 1.3.0-3283c4e8d4d
+  pullPolicy: IfNotPresent
+
+  waitContainer:
+    image:
+        repository: rcosnita/wait-container
+        tag: 1.0.0
+        pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+configuration:
+  telnet:
+    enabled: true
+    port: 4242
+    maxCommandSize: 1024
+  cassandra:
+    maxConcurrentMetricQueries: 20
+    maxQueryReaderThreads: 6
+    replicationFactor: 1
+    readConsistency: LOCAL_QUORUM
+    writeConsistency: LOCAL_QUORUM
+    
+    dataPointsToSend: 200
+    minDataPointsToSend: 100
+    minBatchWaitMs: 500
+
+    memoryQueueSize: 100000
+    secondsTillCheckpointSec: 60
+    pageSizeBytes: 52428800 # 50 MB
+    maxThreadCount: 10 # total number of threads allowed to insert data in Cassandra.
+
+    connection:
+      localCores: 5
+      maxLocalCores: 100
+      remoteCores: 1
+      maxRemoteCores: 10
+      maxRequestsPerLocalConnection: 256
+      maxRequestsPerRemoteConnection: 256
+
+  queryLimit:
+    enabled: false
+    maxDataPoints: 10000000
+    timeoutSec: 60
+  dataPointTTL: 31536000
+  queueSize: 500
+
+service:
+  type: ClusterIP
+  port: 80
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+  hosts:
+    - host: chart-example.local
+      http:
+        paths:
+            - path: /
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+storage:
+  cassandra:
+    enabled: false
+    contactPoints: localhost # comma separated list of hosts which can be used as contact points for cassandra.
+    port: 9042
+  h2:
+    enabled: true
+  hbase:
+    enabled: false # not supported yet
+
+resources:
+  limits:
+    cpu: 1
+    memory: 256Mi
+  requests:
+    cpu: 1
+    memory: 256Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/release_notes.txt
+++ b/release_notes.txt
@@ -3,3 +3,5 @@ Adding new key index that is written using CQL
 Converted queries to use CQL
 Added file backed queue option for ingested data
 Added kairosdb.queries.aggregate_stats=false to aggregate query stats instead of reporting with each call
+Added official dockerfile for building kairosdb in containers.
+Added the first helm chart for deploying kairosdb in kubernetes.


### PR DESCRIPTION
Fixes #606

This is the first version of the helm chart for KairosDB. It allows us to configure cassandra settings based on parameters specified in the **values.yaml** of the helm chart. At the moment, it doesn't support HBase but this can be added at a later stage.