### PR TITLE
Feature/running queries api endpoint and kill queries api endpoint

### DIFF
--- a/src/main/java/org/kairosdb/core/datastore/QueryQueuingManager.java
+++ b/src/main/java/org/kairosdb/core/datastore/QueryQueuingManager.java
@@ -134,6 +134,19 @@ public class QueryQueuingManager implements KairosMetricReporter
 		return runningQueriesList;
 	}
 
+	public void killQuery(String queryHash)
+	{
+		lock.lock();
+		try
+		{
+			runningQueries.get(queryHash).getSecond().interrupt();	// Call interrupt on Thread associated with provided query hash
+		}
+		finally
+		{
+			lock.unlock();
+		}
+	}
+
 	public int getQueryWaitingCount()
 	{
 		return semaphore.getQueueLength();

--- a/src/main/java/org/kairosdb/core/datastore/QueryQueuingManager.java
+++ b/src/main/java/org/kairosdb/core/datastore/QueryQueuingManager.java
@@ -25,6 +25,7 @@ import org.kairosdb.core.reporting.KairosMetricReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -111,6 +112,26 @@ public class QueryQueuingManager implements KairosMetricReporter
 		}
 		else
 			return true;
+	}
+
+	public ArrayList<Pair<String, QueryMetric>> getRunningQueries()
+	{
+		ArrayList<Pair<String, QueryMetric>> runningQueriesList = new ArrayList<Pair<String, QueryMetric>>();
+		lock.lock();
+		ArrayList<String> queryKeys = new ArrayList<String>();
+		queryKeys.addAll(runningQueries.keySet());
+		try
+		{
+			for (String key : queryKeys)
+			{
+				runningQueriesList.add(new Pair<String, QueryMetric>(key, runningQueries.get(key).getFirst()));
+			}
+		}
+		finally
+		{
+			lock.unlock();
+		}
+		return runningQueriesList;
 	}
 
 	public int getQueryWaitingCount()

--- a/src/main/java/org/kairosdb/core/datastore/QueryQueuingManager.java
+++ b/src/main/java/org/kairosdb/core/datastore/QueryQueuingManager.java
@@ -17,6 +17,8 @@ package org.kairosdb.core.datastore;
 
 import com.google.inject.Inject;
 import com.google.inject.name.Named;
+import com.sun.xml.internal.ws.api.message.ExceptionHasMessage;
+import com.typesafe.config.ConfigException;
 import org.agileclick.genorm.runtime.Pair;
 import org.kairosdb.core.DataPoint;
 import org.kairosdb.core.DataPointSet;
@@ -118,11 +120,9 @@ public class QueryQueuingManager implements KairosMetricReporter
 	{
 		ArrayList<Pair<String, QueryMetric>> runningQueriesList = new ArrayList<Pair<String, QueryMetric>>();
 		lock.lock();
-		ArrayList<String> queryKeys = new ArrayList<String>();
-		queryKeys.addAll(runningQueries.keySet());
 		try
 		{
-			for (String key : queryKeys)
+			for (String key : runningQueries.keySet())
 			{
 				runningQueriesList.add(new Pair<String, QueryMetric>(key, runningQueries.get(key).getFirst()));
 			}
@@ -139,7 +139,10 @@ public class QueryQueuingManager implements KairosMetricReporter
 		lock.lock();
 		try
 		{
-			runningQueries.get(queryHash).getSecond().interrupt();	// Call interrupt on Thread associated with provided query hash
+			if (runningQueries.get(queryHash) != null)
+			{
+				runningQueries.get(queryHash).getSecond().interrupt();    // Call interrupt on Thread associated with provided query hash
+			}
 		}
 		finally
 		{

--- a/src/main/java/org/kairosdb/core/http/WebServletModule.java
+++ b/src/main/java/org/kairosdb/core/http/WebServletModule.java
@@ -22,6 +22,7 @@ import com.sun.jersey.guice.JerseyServletModule;
 import com.sun.jersey.guice.spi.container.servlet.GuiceContainer;
 import org.kairosdb.core.KairosRootConfig;
 import org.kairosdb.core.http.exceptionmapper.InvalidServerTypeExceptionMapper;
+import org.kairosdb.core.http.rest.AdminResource;
 import org.kairosdb.core.http.rest.FeaturesResource;
 import org.kairosdb.core.http.rest.MetadataResource;
 import org.kairosdb.core.http.rest.MetricsResource;
@@ -45,6 +46,7 @@ public class WebServletModule extends JerseyServletModule
 		bind(MetricsResource.class).in(Scopes.SINGLETON);
 		bind(MetadataResource.class).in(Scopes.SINGLETON);
 		bind(FeaturesResource.class).in(Scopes.SINGLETON);
+		bind(AdminResource.class).in(Scopes.SINGLETON);
 
 		bind(GuiceContainer.class);
 

--- a/src/main/java/org/kairosdb/core/http/rest/AdminResource.java
+++ b/src/main/java/org/kairosdb/core/http/rest/AdminResource.java
@@ -13,9 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import org.agileclick.genorm.runtime.Pair;
 import javax.inject.Inject;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -62,6 +60,7 @@ public class AdminResource
             responseJson.add("queries", queryInfo);
             responseJson.addProperty("queries waiting", queriesWaitingCount);
 
+            logger.debug("Listing running queries.");
             Response.ResponseBuilder responseBuilder = Response.status(Response.Status.OK).entity(responseJson.toString());
             setHeaders(responseBuilder);
             return responseBuilder.build();
@@ -70,6 +69,24 @@ public class AdminResource
         catch (Exception e)
         {
             logger.error("Failed to get running queries.", e);
+            return setHeaders(Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ErrorResponse(e.getMessage()))).build();
+        }
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
+    @Path("/killquery/{queryHash}")
+    public Response killQueryByHash(@PathParam("queryHash") String queryHash)
+    {
+        try
+        {
+            m_queuingManager.killQuery(queryHash);
+            logger.info("Killed query by hash: " + queryHash);
+            return setHeaders(Response.status(Response.Status.NO_CONTENT)).build();
+        }
+        catch (Exception e)
+        {
+            logger.error("Failed to kill query by hash: " + queryHash, e);
             return setHeaders(Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ErrorResponse(e.getMessage()))).build();
         }
     }

--- a/src/main/java/org/kairosdb/core/http/rest/AdminResource.java
+++ b/src/main/java/org/kairosdb/core/http/rest/AdminResource.java
@@ -55,30 +55,6 @@ public class AdminResource
                 QueryMetric queryMetric = query.getSecond();
                 queryJson.addProperty("query hash", queryHash);
                 queryJson.addProperty("metric name", queryMetric.getName());
-                JsonObject groupBys = new JsonObject();
-                for (GroupBy groupBy : queryMetric.getGroupBys())
-                {
-                    groupBys.addProperty("group by", groupBy.getClass().toString());
-//                    groupBys.addProperty("group by", groupBy.toString());
-                }
-                queryJson.add("group bys", groupBys);
-
-                JsonObject aggs = new JsonObject();
-                for (Aggregator agg : queryMetric.getAggregators())
-                {
-                    aggs.addProperty("aggregator", agg.getClass().toString());
-//                    aggs.addProperty("aggregator", agg.toString());
-                }
-                queryJson.add("aggregators", aggs);
-
-                JsonObject tags = new JsonObject();
-                SetMultimap<String, String> tagSet = queryMetric.getTags();
-                for (String key : tagSet.keySet())
-                {
-                    tags.addProperty(key, tagSet.get(key).toString());
-                }
-                queryJson.add("tags", tags);
-
                 queryJson.add("query JSON", queryMetric.getJsonObj());
 
                 queryInfo.add(queryJson);

--- a/src/main/java/org/kairosdb/core/http/rest/AdminResource.java
+++ b/src/main/java/org/kairosdb/core/http/rest/AdminResource.java
@@ -1,0 +1,101 @@
+package org.kairosdb.core.http.rest;
+
+import com.google.common.collect.SetMultimap;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.kairosdb.core.datastore.QueryMetric;
+import org.kairosdb.core.datastore.QueryQueuingManager;
+import org.kairosdb.core.http.rest.json.ErrorResponse;
+import org.kairosdb.plugin.Aggregator;
+import org.kairosdb.plugin.GroupBy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.agileclick.genorm.runtime.Pair;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import java.util.ArrayList;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.kairosdb.core.http.rest.MetricsResource.setHeaders;
+
+@Path("api/v1/admin")
+public class AdminResource
+{
+    private static final Logger logger = LoggerFactory.getLogger(AdminResource.class);
+
+    private final QueryQueuingManager m_queuingManager;
+
+    @Inject
+    public AdminResource(QueryQueuingManager queuingManager)
+    {
+        this.m_queuingManager = checkNotNull(queuingManager, "queuingManager cannot be null.");
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON + "; charset=UTF-8")
+    @Path("/runningqueries")
+    public Response listRunningQueries()
+    {
+        try
+        {
+            int queriesWaitingCount = m_queuingManager.getQueryWaitingCount();
+            ArrayList<Pair<String, QueryMetric>> runningQueries = m_queuingManager.getRunningQueries();
+            JsonArray queryInfo = new JsonArray();
+
+            JsonObject responseJson = new JsonObject();
+            for (Pair<String, QueryMetric> query : runningQueries) {
+                JsonObject queryJson = new JsonObject();
+                String queryHash = query.getFirst();
+                QueryMetric queryMetric = query.getSecond();
+                queryJson.addProperty("query hash", queryHash);
+                queryJson.addProperty("metric name", queryMetric.getName());
+                JsonObject groupBys = new JsonObject();
+                for (GroupBy groupBy : queryMetric.getGroupBys())
+                {
+                    groupBys.addProperty("group by", groupBy.getClass().toString());
+//                    groupBys.addProperty("group by", groupBy.toString());
+                }
+                queryJson.add("group bys", groupBys);
+
+                JsonObject aggs = new JsonObject();
+                for (Aggregator agg : queryMetric.getAggregators())
+                {
+                    aggs.addProperty("aggregator", agg.getClass().toString());
+//                    aggs.addProperty("aggregator", agg.toString());
+                }
+                queryJson.add("aggregators", aggs);
+
+                JsonObject tags = new JsonObject();
+                SetMultimap<String, String> tagSet = queryMetric.getTags();
+                for (String key : tagSet.keySet())
+                {
+                    tags.addProperty(key, tagSet.get(key).toString());
+                }
+                queryJson.add("tags", tags);
+
+                queryJson.add("query JSON", queryMetric.getJsonObj());
+
+                queryInfo.add(queryJson);
+            }
+            responseJson.add("queries", queryInfo);
+            responseJson.addProperty("queries waiting", queriesWaitingCount);
+
+            Response.ResponseBuilder responseBuilder = Response.status(Response.Status.OK).entity(responseJson.toString());
+            setHeaders(responseBuilder);
+            return responseBuilder.build();
+
+        }
+        catch (Exception e)
+        {
+            logger.error("Failed to get running queries.", e);
+            return setHeaders(Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(new ErrorResponse(e.getMessage()))).build();
+        }
+    }
+
+}


### PR DESCRIPTION
Added AdminResource.java with API endpoints for:
- returning a list of the currently running queries on a KairosDB server along with the current count of queries waiting to run
- killing a currently running query by the query hash returned from the running queries endpoint.
