### PR TITLE
Tweaks to get tests to pass

### DIFF
--- a/build.groovy
+++ b/build.groovy
@@ -211,6 +211,7 @@ junit = new JUnitRule("test").addSources(testSources)
 		.setClasspath(junitClasspath)
 		.addDepends(testCompileRule)
 		.addDepends(ivyTestResolve)
+		.addJvmArgument("-Duser.timezone=UTC")
 
 if (saw.getProperty("jacoco", "false").equals("true"))
 	junit.addJvmArgument("-javaagent:lib_test/jacocoagent.jar=destfile=build/jacoco.exec")
@@ -221,6 +222,7 @@ junitAll = new JUnitRule("test-all").setDescription("Run unit tests including Ca
 		.setClasspath(junitClasspath)
 		.addDepends(testCompileRule)
 		.addDepends(ivyTestResolve)
+		.addJvmArgument("-Duser.timezone=UTC")
 
 if (saw.getProperty("jacoco", "false").equals("true"))
 	junitAll.addJvmArgument("-javaagent:lib_test/jacocoagent.jar=destfile=build/jacoco.exec")
@@ -520,7 +522,7 @@ def doIntegration(Rule rule)
 	integrationClassPath.addPath("build/integration")
 	host = saw.getProperty("host", "127.0.0.1")
 	port = saw.getProperty("port", "8080")
-	saw.exec("java  -Dhost=${host} -Dport=${port} -cp ${integrationClassPath} org.testng.TestNG src/integration-test/testng.xml")
+	saw.exec("java -Duser.timezone=UTC -Dhost=${host} -Dport=${port} -cp ${integrationClassPath} org.testng.TestNG src/integration-test/testng.xml")
 }
 
 //------------------------------------------------------------------------------

--- a/src/test/java/org/kairosdb/datastore/h2/H2DatastoreTest.java
+++ b/src/test/java/org/kairosdb/datastore/h2/H2DatastoreTest.java
@@ -120,12 +120,12 @@ public class H2DatastoreTest extends DatastoreTestHelper
 
 	@Test
 	public void test_serviceKeyStore_singleService()
-			throws DatastoreException
+			throws DatastoreException, InterruptedException
 	{
 		h2Datastore.setValue("Service", "ServiceKey", "key1", "value1");
 		h2Datastore.setValue("Service", "ServiceKey", "key2", "value2");
 		h2Datastore.setValue("Service", "ServiceKey", "foo", "value3");
-
+		Thread.sleep(1);	
 		// Test setValue and getValue
 		assertServiceKeyValue("Service", "ServiceKey", "key1", "value1");
 		assertServiceKeyValue("Service", "ServiceKey", "key2", "value2");
@@ -133,7 +133,9 @@ public class H2DatastoreTest extends DatastoreTestHelper
 
 		// Test lastModified value changes
 		long lastModified = h2Datastore.getValue("Service", "ServiceKey", "key2").getLastModified().getTime();
+		
 		h2Datastore.setValue("Service", "ServiceKey", "key2", "changed");
+		Thread.sleep(1);
 		assertServiceKeyValue("Service", "ServiceKey", "key2", "changed");
 		assertThat(h2Datastore.getValue("Service", "ServiceKey", "key2").getLastModified().getTime(), greaterThan(lastModified));
 
@@ -144,12 +146,14 @@ public class H2DatastoreTest extends DatastoreTestHelper
 		// Test delete
 		lastModified = h2Datastore.getServiceKeyLastModifiedTime("Service", "ServiceKey").getTime();
 		h2Datastore.deleteKey("Service", "ServiceKey", "key2");
+		Thread.sleep(1);
 		assertThat(h2Datastore.listKeys("Service", "ServiceKey"), hasItems("foo", "key1"));
 		assertThat(h2Datastore.getValue("Service", "ServiceKey", "key2"), is(nullValue()));
 		assertThat(h2Datastore.getServiceKeyLastModifiedTime("Service", "ServiceKey").getTime(), greaterThan(lastModified));
 
 		lastModified = h2Datastore.getServiceKeyLastModifiedTime("Service", "ServiceKey").getTime();
 		h2Datastore.deleteKey("Service", "ServiceKey", "foo");
+		Thread.sleep(1);
 		assertThat(h2Datastore.listKeys("Service", "ServiceKey"), hasItems("key1"));
 		assertThat(h2Datastore.getValue("Service", "ServiceKey", "foo"), is(nullValue()));
 		assertThat(h2Datastore.getServiceKeyLastModifiedTime("Service", "ServiceKey").getTime(), greaterThan(lastModified));


### PR DESCRIPTION
1. Add JVM arguments in the build script to force the JVM clock to UTC   (#619)

2. Add a small delay into some last-modified testing operations that can occur faster than a milli and fail greater-than comparison.