### PR TITLE
do not accept datapoint with timestamp >= Cassandra MAX_TTL (20 years)

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/BatchHandler.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/BatchHandler.java
@@ -31,6 +31,8 @@ import static org.kairosdb.datastore.cassandra.CassandraDatastore.getColumnName;
  */
 public class BatchHandler extends RetryCallable
 {
+	/* Cassandra MAX_TTL in seconds */
+	private static final int MAX_TTL_IN_SECONDS = 630720000;
 	public static final Logger logger = LoggerFactory.getLogger(BatchHandler.class);
 	public static final Logger failedLogger = LoggerFactory.getLogger("failed_logger");
 
@@ -113,6 +115,11 @@ public class BatchHandler extends RetryCallable
 				// the resulting aligned ttl is the former calculated ttl minus the datapoint's age
 				ttl = ttl - datapointAgeInSeconds;
 				logger.trace("alligned ttl (seconds): {}", ttl);
+				
+				if (ttl >= MAX_TTL_IN_SECONDS) {
+					logger.warn("ttl ({} seconds) for {} with tags {} is bigger than allowed Cassandra MAX_TTL ({} seconds)", datapointAgeInSeconds, metricName, tags, MAX_TTL_IN_SECONDS);
+					continue;
+				}
 				// if the aligned ttl is negative, the datapoint is already dead
 				if (ttl <= 0)
 				{


### PR DESCRIPTION
# Description
This PR fixes a potential bug that may occur when users try to ingest datapoints with "big" timestamps, for example in _nanoseconds_ instead of _milliseconds_.

The computation of a datapoint's age can be faulty because of the necessary cast to `int`. This could create a value bigger than Cassandra's MAX_TTL of 20 years. Cassandra rejects this which leads to a reduction in KairosDB's batch size and a retry to send the batch. This goes on until KairosDB finally gives up.
This problem is even more serious taking into account it can affect other datapoints in the same batch as well!

With this PR the datapoint's aligned ttl is compared to Cassandra's MAX_TTL first before inserting it to Cassandra. Violating datapoints are logged so users can be informed about this problem.

# Example
Datapoint with timestamp 1588233300000000 (nanoseconds)
The user simply did not pay enough attention when computing the timestamp, so he appended 3 zeros too much.
When inserting this datapoint, the following Cassanda exception occurs:
```
04-30-2020 07:19:55:633 ERROR [BatchHandler.java:206] - Error sending data points
com.datastax.driver.core.exceptions.InvalidQueryException: ttl is too large. requested (1793443580) maximum (630720000)
	at com.datastax.driver.core.exceptions.InvalidQueryException.copy(InvalidQueryException.java:50)
	at com.datastax.driver.core.DriverThrowables.propagateCause(DriverThrowables.java:37)
	at com.datastax.driver.core.DefaultResultSetFuture.getUninterruptibly(DefaultResultSetFuture.java:245)
	at com.datastax.driver.core.AbstractSession.execute(AbstractSession.java:68)
	at org.kairosdb.datastore.cassandra.CQLBatch.submitBatch(CQLBatch.java:180)
```
Now the modified code logs this violation and skips this datapoint.