### PR TITLE
Adding cassandra credentials via kube secrets, configurable through helm

### DIFF
--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -66,6 +66,17 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+          env:
+            - name: CASSANDRA_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.storage.cassandra.authSecret }}
+                  key: username
+            - name: CASSANDRA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.storage.cassandra.authSecret }}
+                  key: password
           livenessProbe:
             httpGet:
               path: /

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -76,6 +76,7 @@ storage:
     enabled: false
     contactPoints: localhost # comma separated list of hosts which can be used as contact points for cassandra.
     port: 9042
+    authSecret: "cassandra-credential-secret"
   h2:
     enabled: true
   hbase:

--- a/src/main/resources/kairosdb.conf
+++ b/src/main/resources/kairosdb.conf
@@ -97,8 +97,7 @@ kairosdb: {
 	#===============================================================================
 	#Configure the datastore
 
-	service.datastore: "org.kairosdb.datastore.h2.H2Module"
-	#service.datastore: "org.kairosdb.datastore.cassandra.CassandraModule"
+	service.datastore: "org.kairosdb.datastore.cassandra.CassandraModule"
 
 	datastore.concurrentQueryThreads: 5
 
@@ -209,8 +208,8 @@ kairosdb: {
 			#for cassandra authentication use the following
 			#auth.[prop name]=[prop value]
 			#example:
-			#auth.user_name=admin
-			#auth.password=eat_me
+			auth.user_name=${?CASSANDRA_USER}
+			auth.password=${?CASSANDRA_PASSWORD}
 
 			# Set this property to true to enable SSL connections to your C* cluster.
 			# Follow the instructions found here: http://docs.datastax.com/en/developer/java-driver/3.1/manual/ssl/

--- a/src/main/resources/kairosdb.properties
+++ b/src/main/resources/kairosdb.properties
@@ -60,9 +60,8 @@ kairosdb.jetty.static_web_root=webroot
 kairosdb.jetty.show_stacktrace=false
 
 #===============================================================================
-kairosdb.service.datastore=org.kairosdb.datastore.h2.H2Module
 kairosdb.datastore.concurrentQueryThreads=5
-#kairosdb.service.datastore=org.kairosdb.datastore.cassandra.CassandraModule
+kairosdb.service.datastore=org.kairosdb.datastore.cassandra.CassandraModule
 #kairosdb.service.datastore=org.kairosdb.datastore.remote.RemoteModule
 
 
@@ -128,8 +127,8 @@ kairosdb.datastore.cassandra.max_queue_size=500
 #for cassandra authentication use the following
 #kairosdb.datastore.cassandra.auth.[prop name]=[prop value]
 #example:
-#kairosdb.datastore.cassandra.auth.user_name=admin
-#kairosdb.datastore.cassandra.auth.password=eat_me
+kairosdb.datastore.cassandra.auth.user_name=${?CASSANDRA_USER}
+kairosdb.datastore.cassandra.auth.password=${?CASSANDRA_PASSWORD}
 
 # Set this property to true to enable SSL connections to your C* cluster.
 # Follow the instructions found here: http://docs.datastax.com/en/developer/java-driver/3.1/manual/ssl/


### PR DESCRIPTION
I had problems with cassandra credentials, so  this is the fix that worked for me. I made the credentials configurable from values.yaml through a secret name, that then gets read from deployment.yaml and gets injected via env vars in the configuration file. One needs to build the docker image and change the version in the chart . 