### PR TITLE
Replace the mention of download section with reference to releases

### DIFF
--- a/src/docs/GettingStarted.rst
+++ b/src/docs/GettingStarted.rst
@@ -8,7 +8,7 @@ Install
 
 KairosDB runs with Java 1.8 or later.
 
-#. Download the tar.gz file from the Downloads section
+#. Download the tar.gz file from the `releases <https://github.com/kairosdb/kairosdb/releases>`_
 #. Extract to where you wish to run from
 #. In conf/kairosdb.properties change the kairosdb.service.datastore property to the datastore you wish to use.  It defaults to an in memory H2 database (that is slow)
 #. Make sure that JAVA_HOME is set to your java install.


### PR DESCRIPTION
The Getting Started page mentioned a "Downloads section" which does not seem to exist. The tar.gz file does exist in the releases page, so I changed it to reference the releases page instead.