### PR TITLE
Fix typo for cassandra auth

### DIFF
--- a/deployment/helm/templates/config.yaml
+++ b/deployment/helm/templates/config.yaml
@@ -180,6 +180,8 @@ data:
                             # Follow the instructions found here: http://docs.datastax.com/en/developer/java-driver/3.1/manual/ssl/
                             # to create a keystore and pass the values into Kairos using the -D switches
                             use_ssl: false
+                            auth.user_name=${?CASSANDRA_USER}
+                            auth.password=${?CASSANDRA_PASSWORD}
 
                             tag_indexed_row_key_lookup_metrics: []
                     }

--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -70,12 +70,12 @@ spec:
             - name: CASSANDRA_USER
               valueFrom:
                 secretKeyRef:
-                  name: { { .Values.storage.cassandra.authSecret } }
+                  name: {{ .Values.storage.cassandra.authSecret }}
                   key: username
             - name: CASSANDRA_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: { { .Values.storage.cassandra.authSecret } }
+                  name: {{ .Values.storage.cassandra.authSecret }}
                   key: password
           livenessProbe:
             httpGet:


### PR DESCRIPTION
There is a typo in autsecret resource usage leading to error message as 
`
Error: YAML parse error on kairosdb/templates/deployment.yaml: error converting YAML to JSON: yaml: invalid map key: map[interface {}]interface {}{".Values.storage.cassandra.authSecret":interface {}(nil)}
`