### PR TITLE
revert pull request 621

### DIFF
--- a/src/main/java/org/kairosdb/datastore/cassandra/BatchHandler.java
+++ b/src/main/java/org/kairosdb/datastore/cassandra/BatchHandler.java
@@ -28,8 +28,6 @@ import java.util.Map;
  */
 public class BatchHandler extends RetryCallable
 {
-	/* Cassandra MAX_TTL in seconds */
-	private static final int MAX_TTL_IN_SECONDS = 630720000;
 	public static final Logger logger = LoggerFactory.getLogger(BatchHandler.class);
 	public static final Logger failedLogger = LoggerFactory.getLogger("failed_logger");
 
@@ -116,10 +114,6 @@ public class BatchHandler extends RetryCallable
 				ttl = ttl - datapointAgeInSeconds;
 				logger.trace("alligned ttl (seconds): {}", ttl);
 				
-				if (ttl >= MAX_TTL_IN_SECONDS) {
-					logger.warn("ttl ({} seconds) for {} with tags {} is bigger than allowed Cassandra MAX_TTL ({} seconds)", datapointAgeInSeconds, metricName, tags, MAX_TTL_IN_SECONDS);
-					continue;
-				}
 				// if the aligned ttl is negative, the datapoint is already dead
 				if (ttl <= 0)
 				{


### PR DESCRIPTION
Cassandra 3 had a _max ttl of 20 years_ ([CASSANDRA-14092](https://issues.apache.org/jira/browse/CASSANDRA-14092)) which made me provide the pull request in the first place.

Cassandra 4 had a hard limit of `2038-01-19T03:14:06+00:00` due to the encoding of localExpirationTime as an int32; furthermore, in Cassandra 5 the hard limit has been raised to `2106-02-07T06:28:13+00:00` ([CASSANDRA-14092.txt](https://github.com/apache/cassandra/blob/cassandra-5.0.0/CASSANDRA-14092.txt)). So there simply is no need for this limitation any more; in fact, this _could_ cause some major irritations.

Those who would like to control how to handle _overflowing_ ttl's can set [-Dcassandra.expiration_date_overflow_policy](https://github.com/apache/cassandra/blob/cassandra-5.0.2/conf/jvm-server.options#L197).